### PR TITLE
Fixed default host

### DIFF
--- a/front-end/src/components/LocalStorageLoader/LocalStorageLoader.tsx
+++ b/front-end/src/components/LocalStorageLoader/LocalStorageLoader.tsx
@@ -78,7 +78,7 @@ const LocalStorageLoader: FC = () => {
     setHost(host);
     setFields(fields);
     // Update API
-    APIOptions.host = `http://${host}`;
+    APIOptions.host = host.startsWith('http') ? host : `http://${host}`;
   }, [host, fields]);
 
   useEffect(() => {


### PR DESCRIPTION
After https://github.com/orange-alliance/project-ems/commit/49ba54d1965d133cf3ac2009ab127f7aa9c4fc48, the host address may go wrong and start at ``http://http://<IP>``

These 2 lines add ``http://`` to the same localstorage variable.
https://github.com/orange-alliance/project-ems/blob/acdc3a624c3aafe2514c0072263b17b2832be1ba/front-end/src/apps/Settings/index.tsx#L105
https://github.com/orange-alliance/project-ems/blob/49ba54d1965d133cf3ac2009ab127f7aa9c4fc48/front-end/src/components/LocalStorageLoader/LocalStorageLoader.tsx#L81


<img width="647" src="https://user-images.githubusercontent.com/16443111/194727549-8def36c0-075e-463e-bf8d-fef00d491e71.png">
