### PR TITLE
Overhaul rank handling in audience display with retries and stale rank handling

### DIFF
--- a/apps/web/src/api/events/display-event.ts
+++ b/apps/web/src/api/events/display-event.ts
@@ -1,7 +1,54 @@
-import { useSetAtom } from 'jotai';
+import { Displays } from '@toa-lib/models';
+import { useAtomCallback } from 'jotai/utils';
 import { displayIdAtom } from 'src/stores/state/audience-display.js';
+import { matchAtom, matchOccurringRanksAtom } from 'src/stores/state/event.js';
+import { ensurePostCommitRanks } from './post-commit-ranks.js';
+
+// How long to hold the switch to the results screen while waiting for fresh
+// rankings before giving up and showing it with ranks hidden.
+const SHOW_RESULTS_DEADLINE_MS = 5000;
+
+// Bumped on every display event so a superseded results handler (still
+// awaiting its rankings fetch) can tell it lost and must not touch state.
+let displaySeq = 0;
 
 export const useDisplayEvent = () => {
-  const setDisplay = useSetAtom(displayIdAtom)
-  return (id: number) => setDisplay(id);
+  return useAtomCallback(async (get, set, id: number) => {
+    const seq = ++displaySeq;
+
+    if (id !== Displays.MATCH_RESULTS) {
+      set(displayIdAtom, id);
+      return;
+    }
+
+    const match = get(matchAtom);
+    if (!match) {
+      // Cold start / replay before match state arrives. Show the screen —
+      // DisplaySwitcher renders nothing without a match anyway, and the
+      // COMMIT/PRESTART replays will populate match + ranks.
+      set(displayIdAtom, id);
+      return;
+    }
+
+    // Reuse the post-commit rankings fetch if the commit handler already
+    // started one; otherwise start it now. Hold the screen switch until it
+    // resolves or the deadline passes, so stale ranks never flash on screen.
+    const outcome = await Promise.race([
+      ensurePostCommitRanks(get, set, match),
+      new Promise<'deadline'>((resolve) =>
+        setTimeout(() => resolve('deadline'), SHOW_RESULTS_DEADLINE_MS)
+      )
+    ]);
+
+    // A newer display event took over while we waited — do nothing.
+    if (seq !== displaySeq) return;
+
+    if (outcome === 'deadline' || outcome === null) {
+      // Failure or deadline: hide ranks rather than risk showing wrong ones.
+      // If the fetch is still in flight and later succeeds, the shared
+      // promise fills the ranks in live.
+      set(matchOccurringRanksAtom, []);
+    }
+    set(displayIdAtom, id);
+  });
 };

--- a/apps/web/src/api/events/display-event.ts
+++ b/apps/web/src/api/events/display-event.ts
@@ -33,12 +33,19 @@ export const useDisplayEvent = () => {
     // Reuse the post-commit rankings fetch if the commit handler already
     // started one; otherwise start it now. Hold the screen switch until it
     // resolves or the deadline passes, so stale ranks never flash on screen.
+    let resolveDeadline!: (value: 'deadline') => void;
+    const deadline = new Promise<'deadline'>((resolve) => {
+      resolveDeadline = resolve;
+    });
+    const deadlineTimer = setTimeout(
+      () => resolveDeadline('deadline'),
+      SHOW_RESULTS_DEADLINE_MS
+    );
     const outcome = await Promise.race([
       ensurePostCommitRanks(get, set, match),
-      new Promise<'deadline'>((resolve) =>
-        setTimeout(() => resolve('deadline'), SHOW_RESULTS_DEADLINE_MS)
-      )
+      deadline
     ]);
+    clearTimeout(deadlineTimer);
 
     // A newer display event took over while we waited — do nothing.
     if (seq !== displaySeq) return;

--- a/apps/web/src/api/events/is-same-match.ts
+++ b/apps/web/src/api/events/is-same-match.ts
@@ -1,0 +1,14 @@
+import { MatchKey } from '@toa-lib/models';
+
+/**
+ * Whether the given (possibly null) match refers to the same match as key.
+ * Used to drop delayed fetch responses once a newer match owns the state.
+ */
+export const isSameMatch = (
+  match: MatchKey | null | undefined,
+  key: MatchKey
+): boolean =>
+  !!match &&
+  match.eventKey === key.eventKey &&
+  match.tournamentKey === key.tournamentKey &&
+  match.id === key.id;

--- a/apps/web/src/api/events/match-commit-event.ts
+++ b/apps/web/src/api/events/match-commit-event.ts
@@ -1,20 +1,9 @@
-import { apiFetcher } from '@toa-lib/client';
-import { MatchKey, rankingZod } from '@toa-lib/models';
+import { MatchKey } from '@toa-lib/models';
 import { useAtomCallback } from 'jotai/utils';
-import { matchOccurringRanksAtom } from 'src/stores/state/event.js';
+import { ensurePostCommitRanks } from './post-commit-ranks.js';
 
 export const useCommitEvent = () => {
-  return useAtomCallback(
-    (get, set) =>
-      async ({ eventKey, tournamentKey, id }: MatchKey) => {
-        const rankings = await apiFetcher(
-          `ranking/${eventKey}/${tournamentKey}/${id}`,
-          'GET',
-          undefined,
-          rankingZod.array().parse
-        );
-
-        set(matchOccurringRanksAtom, rankings);
-      }
-  );
+  return useAtomCallback(async (get, set, key: MatchKey) => {
+    await ensurePostCommitRanks(get, set, key);
+  });
 };

--- a/apps/web/src/api/events/match-prestart-event.ts
+++ b/apps/web/src/api/events/match-prestart-event.ts
@@ -4,6 +4,7 @@ import {
   Match,
   MatchDetailBase,
   matchZod,
+  Ranking,
   getSeasonKeyFromEventKey,
   getDefaultMatchDetailsBySeasonKey
 } from '@toa-lib/models';
@@ -34,7 +35,14 @@ export const usePrestartEvent = () => {
           matchZod.parse
         )
       );
-      const rankings = await fetchMatchRankings(key);
+      let rankings: Ranking[] = [];
+      try {
+        rankings = await fetchMatchRankings(key);
+      } catch (e) {
+        // Rankings are best-effort here — still show the new match rather
+        // than aborting the whole prestart and leaving the display stuck.
+        console.error('Failed to fetch rankings for match prestart', e);
+      }
       const seasonKey = getSeasonKeyFromEventKey(eventKey);
       const details = getDefaultMatchDetailsBySeasonKey(seasonKey);
       match.details = { eventKey, id, tournamentKey, ...details };

--- a/apps/web/src/api/events/match-prestart-event.ts
+++ b/apps/web/src/api/events/match-prestart-event.ts
@@ -4,49 +4,60 @@ import {
   Match,
   MatchDetailBase,
   matchZod,
-  Ranking,
-  rankingZod,
   getSeasonKeyFromEventKey,
   getDefaultMatchDetailsBySeasonKey
 } from '@toa-lib/models';
 import { useSetAtom } from 'jotai';
-import { matchAtom, matchOccurringRanksAtom } from 'src/stores/state/event.js';
+import {
+  matchAtom,
+  matchOccurringRanksAtom,
+  postCommitRanksFetchAtom
+} from 'src/stores/state/event.js';
+import { fetchMatchRankings } from 'src/api/use-ranking-data.js';
+import { withRetry } from 'src/api/with-retry.js';
 
 export const usePrestartEvent = () => {
   const setMatch = useSetAtom(matchAtom);
   const setMatchRanks = useSetAtom(matchOccurringRanksAtom);
+  const setPostCommitRanksFetch = useSetAtom(postCommitRanksFetchAtom);
 
   return async (key: MatchKey) => {
     const { eventKey, id, tournamentKey } = key;
-    const match: Match<MatchDetailBase> = await apiFetcher(
-      `match/all/${eventKey}/${tournamentKey}/${id}`,
-      'GET',
-      undefined,
-      matchZod.parse
-    );
-    const rankings: Ranking[] = await apiFetcher(
-      `ranking/${eventKey}/${tournamentKey}/${id}`,
-      'GET',
-      undefined,
-      rankingZod.array().parse
-    );
-    const seasonKey = getSeasonKeyFromEventKey(eventKey);
-    const details = getDefaultMatchDetailsBySeasonKey(seasonKey);
-    match.details = { eventKey, id, tournamentKey, ...details };
-    match.redMinPen = 0;
-    match.blueMinPen = 0;
-    match.redScore = 0;
-    match.blueScore = 0;
-    match.result = -1;
-    // Reset participant cards
-    if (match.participants) {
-      for (const participant of match.participants) {
-        participant.cardStatus = 0;
-        participant.disqualified = 0;
-        participant.noShow = 0;
+    // New match cycle — the previous match's post-commit fetch is done with.
+    setPostCommitRanksFetch(null);
+    try {
+      const match: Match<MatchDetailBase> = await withRetry(() =>
+        apiFetcher(
+          `match/all/${eventKey}/${tournamentKey}/${id}`,
+          'GET',
+          undefined,
+          matchZod.parse
+        )
+      );
+      const rankings = await fetchMatchRankings(key);
+      const seasonKey = getSeasonKeyFromEventKey(eventKey);
+      const details = getDefaultMatchDetailsBySeasonKey(seasonKey);
+      match.details = { eventKey, id, tournamentKey, ...details };
+      match.redMinPen = 0;
+      match.blueMinPen = 0;
+      match.redScore = 0;
+      match.blueScore = 0;
+      match.result = -1;
+      // Reset participant cards
+      if (match.participants) {
+        for (const participant of match.participants) {
+          participant.cardStatus = 0;
+          participant.disqualified = 0;
+          participant.noShow = 0;
+        }
       }
+      setMatch(match);
+      setMatchRanks(rankings);
+    } catch (e) {
+      // This handler runs inside a comlink-proxied callback, so a rejection
+      // here would otherwise disappear without a trace — leaving the display
+      // silently stuck on the previous match.
+      console.error('Failed to handle match prestart', e);
     }
-    setMatch(match);
-    setMatchRanks(rankings);
   };
 };

--- a/apps/web/src/api/events/post-commit-ranks.ts
+++ b/apps/web/src/api/events/post-commit-ranks.ts
@@ -1,0 +1,47 @@
+import { MatchKey, Ranking } from '@toa-lib/models';
+import { Getter, Setter } from 'jotai';
+import {
+  matchAtom,
+  matchOccurringRanksAtom,
+  postCommitRanksFetchAtom
+} from 'src/stores/state/event.js';
+import { fetchMatchRankings } from 'src/api/use-ranking-data.js';
+import { isSameMatch } from './is-same-match.js';
+
+/**
+ * Returns the shared post-commit rankings fetch for the given match, starting
+ * one if none exists yet. The commit and display event handlers both call
+ * this, so whichever fires first owns the network request and the other
+ * reuses its promise — no double-call. The rankings are applied to
+ * matchOccurringRanksAtom whenever the fetch resolves (early is fine —
+ * preview screens hide ranks once the match has started; late fills the
+ * results screen in live). Resolves null if all retries failed, in which
+ * case the cache entry is cleared so a later caller can retry fresh.
+ */
+export const ensurePostCommitRanks = (
+  get: Getter,
+  set: Setter,
+  key: MatchKey
+): Promise<Ranking[] | null> => {
+  const existing = get(postCommitRanksFetchAtom);
+  if (existing && isSameMatch(existing.key, key)) {
+    return existing.promise;
+  }
+  const promise = fetchMatchRankings(key)
+    .then((rankings) => {
+      // Don't stomp a newer match's ranks with a delayed response.
+      if (isSameMatch(get(matchAtom), key)) {
+        set(matchOccurringRanksAtom, rankings);
+      }
+      return rankings;
+    })
+    .catch((e) => {
+      console.error('Failed to fetch post-commit rankings', e);
+      if (get(postCommitRanksFetchAtom)?.promise === promise) {
+        set(postCommitRanksFetchAtom, null);
+      }
+      return null;
+    });
+  set(postCommitRanksFetchAtom, { key, promise });
+  return promise;
+};

--- a/apps/web/src/api/use-ranking-data.ts
+++ b/apps/web/src/api/use-ranking-data.ts
@@ -1,6 +1,7 @@
 import { apiFetcher } from '@toa-lib/client';
-import { Team, Ranking } from '@toa-lib/models';
+import { MatchKey, Team, Ranking, rankingZod } from '@toa-lib/models';
 import useSWR from 'swr';
+import { withRetry } from './with-retry.js';
 
 export const createRankings = (
   tournamentKey: string,
@@ -30,6 +31,26 @@ export const recalculatePlayoffsRankings = (
 
 export const deleteRankings = (eventKey: string, tournamentKey: string) =>
   apiFetcher(`ranking/${eventKey}/${tournamentKey}`, 'DELETE');
+
+/**
+ * Fetches the rankings for the teams participating in the given match.
+ * Returns the current rankings from the API (post-match once scores have
+ * been committed and rankings recalculated). Retries transient failures
+ * before rethrowing the last error.
+ */
+export const fetchMatchRankings = ({
+  eventKey,
+  tournamentKey,
+  id
+}: MatchKey): Promise<Ranking[]> =>
+  withRetry(() =>
+    apiFetcher(
+      `ranking/${eventKey}/${tournamentKey}/${id}`,
+      'GET',
+      undefined,
+      rankingZod.array().parse
+    )
+  );
 
 export const useRankingsForTournament = (
   eventKey: string | null | undefined,

--- a/apps/web/src/api/with-retry.ts
+++ b/apps/web/src/api/with-retry.ts
@@ -1,0 +1,21 @@
+// Default delays between retry attempts. Kept short enough that a late
+// success still corrects audience-display state while it's on screen.
+const DEFAULT_RETRY_DELAYS_MS = [1000, 3000];
+
+/**
+ * Runs fn, retrying transient failures after each delay in delaysMs before
+ * rethrowing the last error (total attempts = delaysMs.length + 1).
+ */
+export const withRetry = async <T>(
+  fn: () => Promise<T>,
+  delaysMs: number[] = DEFAULT_RETRY_DELAYS_MS
+): Promise<T> => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (attempt >= delaysMs.length) throw e;
+      await new Promise((resolve) => setTimeout(resolve, delaysMs[attempt]));
+    }
+  }
+};

--- a/apps/web/src/apps/audience-display/displays/display-switcher.tsx
+++ b/apps/web/src/apps/audience-display/displays/display-switcher.tsx
@@ -4,8 +4,7 @@ import {
   AudienceScreens,
   Displays,
   LayoutMode,
-  MatchState,
-  Ranking
+  MatchState
 } from '@toa-lib/models';
 import { getDisplays } from './displays.js';
 import { FadeInOut, SlideInBottom } from 'src/components/animations/index.js';
@@ -27,9 +26,7 @@ export interface DisplayModeProps {
 }
 export const DisplaySwitcher: FC<DisplayModeProps> = ({ id }) => {
   const match = useAtomValue(matchAtom);
-  // const matchResultsMatch = useAtomValue(matchResultsMatchAtom);
   const ranks = useAtomValue(matchOccurringRanksAtom);
-  const matchResultsRanks: Ranking[] = []; // useAtomValue(matchResultsRanksAtom);
   const [audDispChroma, setAudDisplayChroma] = useAtom(displayChromaKeyAtom);
   const matchState = useAtomValue(matchStateAtom);
   const [searchParams] = useSearchParams();
@@ -41,6 +38,10 @@ export const DisplaySwitcher: FC<DisplayModeProps> = ({ id }) => {
   } = useEventState({
     teams: true
   });
+
+  // Hide ranks on preview screens once the match has started — they'd spoil
+  // the results once post-match rankings are fetched at commit time.
+  const showRanks = matchState < MatchState.MATCH_IN_PROGRESS;
 
   // Pin a display
   const pin = searchParams.get('pin');
@@ -71,14 +72,18 @@ export const DisplaySwitcher: FC<DisplayModeProps> = ({ id }) => {
     switch (pin) {
       case AudienceScreens.PREVIEW:
         return (
-          <displays.matchPreview event={event} match={match} ranks={ranks} />
+          <displays.matchPreview
+            event={event}
+            match={match}
+            ranks={showRanks ? ranks : []}
+          />
         );
       case AudienceScreens.PREVIEW_STREAM:
         return (
           <displays.matchPreviewStream
             event={event}
             match={match}
-            ranks={ranks}
+            ranks={showRanks ? ranks : []}
           />
         );
       case AudienceScreens.MATCH:
@@ -145,8 +150,6 @@ export const DisplaySwitcher: FC<DisplayModeProps> = ({ id }) => {
     matchState > MatchState.MATCH_IN_PROGRESS &&
     matchState < MatchState.RESULTS_POSTED;
 
-  const showRanks = matchState < MatchState.MATCH_IN_PROGRESS;
-
   const showPreviewFull =
     layout[0] === LayoutMode.FULL || layout[1] === LayoutMode.FULL;
 
@@ -165,9 +168,6 @@ export const DisplaySwitcher: FC<DisplayModeProps> = ({ id }) => {
   // force hide the preview if we are showing the results
   const forceHidePreview =
     showStreamResultsDuringPreview || showFullResultsDuringPreview;
-
-  const resultsToUse = match;
-  const ranksToUse = !matchResultsRanks ? ranks : matchResultsRanks;
 
   return (
     <>
@@ -204,7 +204,7 @@ export const DisplaySwitcher: FC<DisplayModeProps> = ({ id }) => {
             <displays.matchPreviewStream
               event={event}
               match={match}
-              ranks={ranks}
+              ranks={showRanks ? ranks : []}
               teams={teams}
             />
           </SlideInBottom>
@@ -272,14 +272,14 @@ export const DisplaySwitcher: FC<DisplayModeProps> = ({ id }) => {
           >
             <displays.matchResults
               event={event}
-              match={resultsToUse}
-              ranks={ranksToUse}
+              match={match}
+              ranks={ranks}
               teams={teams}
             />
           </FadeInOut>
         </AbsolouteLocator>
       )}
-      {layout[2] === LayoutMode.STREAM && resultsToUse && (
+      {layout[2] === LayoutMode.STREAM && (
         <AbsolouteLocator top={0} left={0}>
           <SlideInBottom
             in={id === Displays.MATCH_RESULTS || showStreamResultsDuringPreview}
@@ -288,8 +288,8 @@ export const DisplaySwitcher: FC<DisplayModeProps> = ({ id }) => {
           >
             <displays.matchResultsStream
               event={event}
-              match={resultsToUse}
-              ranks={ranksToUse}
+              match={match}
+              ranks={ranks}
               teams={teams}
             />
           </SlideInBottom>

--- a/apps/web/src/apps/audience-display/displays/seasons/fgc_default_v2/components/alliance-team.tsx
+++ b/apps/web/src/apps/audience-display/displays/seasons/fgc_default_v2/components/alliance-team.tsx
@@ -11,6 +11,7 @@ interface AllianceTeamProps {
   large?: boolean;
   noBg?: boolean;
   noRankChange?: boolean;
+  hideRanks?: boolean;
 }
 
 const calcRankChange = (ranks: Ranking[], team: MatchParticipant) => {
@@ -25,7 +26,8 @@ const AllianceTeam: React.FC<AllianceTeamProps> = ({
   team,
   large = false,
   noBg = false,
-  noRankChange = false
+  noRankChange = false,
+  hideRanks = false
 }) => {
   const ranks: Ranking[] = useAtomValue(matchOccurringRanksAtom);
 
@@ -76,22 +78,28 @@ const AllianceTeam: React.FC<AllianceTeamProps> = ({
       >
         <CardStatus cardStatus={team.cardStatus} />
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <span
-          style={{ fontWeight: 'bold', fontSize: rankFontSize, color: 'white' }}
-        >
-          #{currentRank ? currentRank.rank : '-'}
-        </span>
-        {!noRankChange && up ? (
-          <span style={{ color: '#16a34a', fontSize: iconFontSize }}>▲</span>
-        ) : null}
-        {!noRankChange && down ? (
-          <span style={{ color: '#dc2626', fontSize: iconFontSize }}>▼</span>
-        ) : null}
-        {!noRankChange && !up && !down ? (
-          <span style={{ color: '#9ca3af', fontSize: iconFontSize }}>━</span>
-        ) : null}
-      </div>
+      {!hideRanks && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span
+            style={{
+              fontWeight: 'bold',
+              fontSize: rankFontSize,
+              color: 'white'
+            }}
+          >
+            #{currentRank ? currentRank.rank : '-'}
+          </span>
+          {!noRankChange && up ? (
+            <span style={{ color: '#16a34a', fontSize: iconFontSize }}>▲</span>
+          ) : null}
+          {!noRankChange && down ? (
+            <span style={{ color: '#dc2626', fontSize: iconFontSize }}>▼</span>
+          ) : null}
+          {!noRankChange && !up && !down ? (
+            <span style={{ color: '#9ca3af', fontSize: iconFontSize }}>━</span>
+          ) : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/apps/audience-display/displays/seasons/fgc_default_v2/match-preview-stream.tsx
+++ b/apps/web/src/apps/audience-display/displays/seasons/fgc_default_v2/match-preview-stream.tsx
@@ -1,13 +1,19 @@
 import { FC } from 'react';
 import { DisplayProps } from '../../displays.js';
 import { Space } from 'antd';
-import { MatchParticipant } from '@toa-lib/models';
+import { MatchParticipant, MatchState } from '@toa-lib/models';
+import { useAtomValue } from 'jotai';
 import AllianceTeam from './components/alliance-team.js';
 import AllianceBox from './components/alliance-box.js';
 import L3Header from './components/l3-header.js';
 import { useAllianceMember } from 'src/api/use-alliance-data.js';
+import { matchStateAtom } from 'src/stores/state/match.js';
 
 export const MatchPreviewStream: FC<DisplayProps> = ({ match }) => {
+  const matchState = useAtomValue(matchStateAtom);
+  // Once the match has started, ranks become spoilers — post-match rankings
+  // are fetched into the shared ranks atom when scores are committed.
+  const hideRanks = matchState >= MatchState.MATCH_IN_PROGRESS;
   const redTeams: MatchParticipant[] = [];
   const blueTeams: MatchParticipant[] = [];
 
@@ -81,6 +87,7 @@ export const MatchPreviewStream: FC<DisplayProps> = ({ match }) => {
                 noBg
                 noRankChange
                 large
+                hideRanks={hideRanks}
               />
             ))}
           </Space>
@@ -94,6 +101,7 @@ export const MatchPreviewStream: FC<DisplayProps> = ({ match }) => {
                 noBg
                 noRankChange
                 large
+                hideRanks={hideRanks}
               />
             ))}
           </Space>

--- a/apps/web/src/stores/state/event.ts
+++ b/apps/web/src/stores/state/event.ts
@@ -5,6 +5,7 @@ import {
   Team,
   Tournament,
   Match,
+  MatchKey,
   Ranking
 } from '@toa-lib/models';
 import { atom } from 'jotai';
@@ -79,6 +80,15 @@ export const scheduleParamsAtom = atom<ScheduleParams[]>([]);
 export const scheduleItemsAtom = atom<ScheduleItem[]>([]);
 export const matchesAtom = atom<Match<any>[]>([]);
 export const matchOccurringRanksAtom = atom<Ranking[]>([]);
+
+// The one in-flight/settled post-commit rankings fetch for the current match.
+// Shared between the commit and display event handlers so showing the results
+// screen doesn't refetch what the commit already fetched. Reset at prestart.
+export interface PostCommitRanksFetch {
+  key: MatchKey;
+  promise: Promise<Ranking[] | null>; // resolves null if all retries failed
+}
+export const postCommitRanksFetchAtom = atom<PostCommitRanksFetch | null>(null);
 
 /**
  * @section MODIFIED STATE - modified state for unsaved changes


### PR DESCRIPTION
This pull request introduces significant improvements to how audience display screens handle and synchronize match rankings, particularly around match transitions and result displays. The main goals are to prevent stale or incorrect rankings from flashing on screen during network delays, ensure rankings are fetched and shared efficiently, and avoid spoilers by hiding ranks at appropriate times. The changes also improve error handling and code clarity.

**Key improvements and features:**

### Reliable, Shared Rankings Fetching and State Synchronization

* Introduced `ensurePostCommitRanks` in `post-commit-ranks.ts` to coordinate a single fetch for post-commit rankings per match, ensuring that both commit and display events share the same network request and state update, and preventing race conditions or double-fetching.
* Updated `useDisplayEvent` and `useCommitEvent` to use the shared rankings fetch logic, holding the results screen until fresh rankings are available or a timeout occurs, and hiding ranks if the fetch fails or times out. [[1]](diffhunk://#diff-54a07d715934cc12146323c8a7c59c469ced5799c172e09e27efcb01351c574dL1-R53) [[2]](diffhunk://#diff-26323736c7207b1bfe02608499d7e201a455a9f1bd0c5da197038bc3cf7b2e19L1-R8)

### Rankings Fetching Robustness

* Added `withRetry` utility for robust API calls, retrying transient failures with short delays to maximize the chance of displaying up-to-date rankings.
* Refactored `fetchMatchRankings` to use `withRetry` and centralized match rankings fetching logic.

### Display Logic and Spoiler Prevention

* Updated display components (e.g., `display-switcher.tsx`, `match-preview-stream.tsx`, and `alliance-team.tsx`) to hide rankings on preview screens once a match has started, preventing spoilers and ensuring that only valid, up-to-date rankings are shown. [[1]](diffhunk://#diff-5ce16ad31669f125d63b286e3760b304f072dbea66f9a65c0366bf4d52c0d52cR42-R45) [[2]](diffhunk://#diff-5ce16ad31669f125d63b286e3760b304f072dbea66f9a65c0366bf4d52c0d52cL74-R86) [[3]](diffhunk://#diff-a4a75381fd3e9c759b9e3992d7799da71e76685e207a408495feea416434af62L4-R16) [[4]](diffhunk://#diff-a4a75381fd3e9c759b9e3992d7799da71e76685e207a408495feea416434af62R90) [[5]](diffhunk://#diff-9d3615913cc1d715beae7c49e30084f7e2a3558a7fc2bf5114b5bad1d4e4788aR81-R88)
* Added `hideRanks` prop to relevant components to control visibility of rankings based on match state. [[1]](diffhunk://#diff-9d3615913cc1d715beae7c49e30084f7e2a3558a7fc2bf5114b5bad1d4e4788aR14) [[2]](diffhunk://#diff-9d3615913cc1d715beae7c49e30084f7e2a3558a7fc2bf5114b5bad1d4e4788aL28-R30)

### Error Handling and Code Quality

* Improved error handling in event handlers to ensure failures are logged and do not leave the display in an inconsistent state.
* Added `isSameMatch` utility to reliably compare match keys and drop delayed fetch responses for superseded matches.

These changes together make the audience display more robust, responsive, and user-friendly, especially around match transitions and result postings.…ies, and hiding potentially stale ranks.