### PR TITLE
Fix playoff matches created with startTime pre-set

### DIFF
--- a/libs/models/src/base/Match.ts
+++ b/libs/models/src/base/Match.ts
@@ -199,7 +199,7 @@ export function createFixedMatches(
       redMinPen: 0,
       redScore: 0,
       scheduledTime: item.startTime,
-      startTime: item.startTime,
+      startTime: '',
       uploaded: 0
     };
     const matchAllianceMap = matchMap[matchNumber];


### PR DESCRIPTION
## Summary
- `createFixedMatches` (used to generate playoff-style matches — Round Robin/Finals brackets) was setting `startTime` to the schedule slot time at match creation, before the match had ever actually run.
- Qualification match creation (`parseMatchMaker` in `libs/server/src/MatchMaker.ts`) already leaves `startTime: ''` until the match is actually started; this brings playoff match creation in line with that convention.
- `startTime` is part of the public `Match` API/webhook schema, so this previously caused every playoff match to falsely appear "started" the moment the bracket was generated.

Fixes #223

## Test plan
- [x] `nx build models` passes with no type errors
- [x] Generate a Round Robin/Finals playoff schedule in the web app and confirm created matches have `startTime: ''` and a correctly populated `scheduledTime`
- [x] Confirm qualification match generation (`RandomMatches`) is unaffected