### PR TITLE
Make API/webhook match fields accurate end-to-end

### DIFF
--- a/apps/services/api/sql/create_event.sql
+++ b/apps/services/api/sql/create_event.sql
@@ -103,7 +103,7 @@ CREATE TABLE IF NOT EXISTS "match" (
     "id" INT NOT NULL,
     "name" VARCHAR(50) NOT NULL,
     "scheduledTime" VARCHAR(255),
-    "startTime" VARCHAR(255),
+    "actualStartTime" VARCHAR(255),
     "prestartTime" VARCHAR(255),
     "fieldNumber" INT,
     "cycleTime" REAL,

--- a/apps/services/api/sql/create_global.sql
+++ b/apps/services/api/sql/create_global.sql
@@ -17,7 +17,6 @@ CREATE TABLE IF NOT EXISTS "event" (
 );
 
 CREATE TABLE IF NOT EXISTS "socket_clients" (
-    "currentUrl" VARCHAR(255),
     "ipAddress" VARCHAR(64) NOT NULL,
     "fieldNumbers" VARCHAR(255),
     "audienceDisplayChroma" VARCHAR(255),

--- a/apps/services/api/src/controllers/Match.ts
+++ b/apps/services/api/src/controllers/Match.ts
@@ -34,6 +34,7 @@ import {
 } from '../util/GlobalSchema.js';
 import { matchWithDetailsZod } from '@toa-lib/models/base';
 import { platform } from 'os';
+import { computeCycleTime } from '../util/CycleTime.js';
 
 const MatchArraySchema = z.array(matchWithDetailsZod);
 const MatchParticipantArraySchema = z.array(matchParticipantZod);
@@ -317,6 +318,22 @@ async function matchController(fastify: FastifyInstance) {
         const match = request.body as z.infer<typeof matchWithDetailsZod>;
         if (match.details) delete match.details;
         if (match.participants) delete match.participants;
+
+        // Cycle time is derived, never client-supplied, so that every client
+        // agrees on it. Recomputed only on the patch that first records this
+        // match's actual start — later patches (commit, score edits) resend the
+        // same actualStartTime and must not disturb the stored value.
+        const [stored] = await db.selectAllWhere(
+          'match',
+          `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id = ${id}`
+        );
+        if (
+          match.actualStartTime &&
+          match.actualStartTime !== stored?.actualStartTime
+        ) {
+          const cycleTime = await computeCycleTime(db, match);
+          if (cycleTime !== null) match.cycleTime = cycleTime;
+        }
 
         if (match.active === 1) {
           await db.updateWhere(

--- a/apps/services/api/src/controllers/SocketClients.ts
+++ b/apps/services/api/src/controllers/SocketClients.ts
@@ -29,7 +29,10 @@ const disconnectParamsSchema = z.object({
 });
 
 const socketClientSchema = connectBodySchema.extend({
-  // Add any additional fields returned by DB if needed
+  // Set server-side from `request.ip` on connect. It was missing from this
+  // schema, and since the zod serializer strips anything undeclared, the
+  // display manager's IP column came back blank on every row.
+  ipAddress: z.string().optional()
 });
 const socketClientArraySchema = z.array(socketClientSchema);
 

--- a/apps/services/api/src/db/EventDatabase.ts
+++ b/apps/services/api/src/db/EventDatabase.ts
@@ -49,9 +49,65 @@ export class EventDatabase {
       this.db = await AsyncDatabase.open(
         getAppData('ems') + sep + this.name + '.db'
       );
+      await this.runMigrations();
     } catch (e) {
       throw e;
     }
+  }
+
+  /**
+   * Brings an already-existing database file up to date with the current schema.
+   *
+   * Every `create_*.sql` uses `CREATE TABLE IF NOT EXISTS`, which means schema
+   * changes to those files only ever reach *new* databases — an event created
+   * before a column was renamed would silently keep the old column and drop
+   * writes to the new one on the floor. This is the seam where those changes get
+   * applied to existing databases instead.
+   *
+   * Contract for every step in here:
+   *  - **Idempotent.** This runs on every database open, so a step that has
+   *    already been applied must be a no-op, not an error.
+   *  - **Safe on a fresh database.** A brand new event DB has no tables at all
+   *    until `createEventBase()` runs, so each step must check that its table
+   *    exists before touching it.
+   */
+  public async runMigrations(): Promise<void> {
+    // startTime -> actualStartTime. The old name read like "when the match
+    // started" but actually held the scheduled time; see issue #236.
+    await this.renameColumnIfPresent('match', 'startTime', 'actualStartTime');
+  }
+
+  /**
+   * Renames `from` to `to` on `table`, but only if the rename is actually
+   * pending — i.e. the table exists, still has the old column, and does not yet
+   * have the new one. Any other state is treated as already-migrated.
+   */
+  private async renameColumnIfPresent(
+    table: string,
+    from: string,
+    to: string
+  ): Promise<void> {
+    try {
+      if (!(await this.tableExists(table))) return;
+      const columns = (await this.db.all(
+        `PRAGMA table_info("${table}");`
+      )) as { name: string }[];
+      const names = columns.map((c) => c.name);
+      if (!names.includes(from) || names.includes(to)) return;
+      await this.db.exec(
+        `ALTER TABLE "${table}" RENAME COLUMN "${from}" TO "${to}";`
+      );
+    } catch (e) {
+      throw new ApiDatabaseError(table, e);
+    }
+  }
+
+  private async tableExists(table: string): Promise<boolean> {
+    const rows = await this.db.all(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?;`,
+      [table]
+    );
+    return rows.length > 0;
   }
 
   public async setupUsers(): Promise<void> {

--- a/apps/services/api/src/util/CycleTime.ts
+++ b/apps/services/api/src/util/CycleTime.ts
@@ -1,0 +1,56 @@
+import { EventDatabase } from '../db/EventDatabase.js';
+
+/** Shape of the fields `computeCycleTime` needs off a match. */
+interface CycleTimeInput {
+  eventKey: string;
+  tournamentKey: string;
+  id: number;
+  fieldNumber: number;
+  actualStartTime: string;
+}
+
+/**
+ * Cycle time for a match, in **fractional minutes**.
+ *
+ * Defined as the elapsed time between this match's `actualStartTime` and the
+ * `actualStartTime` of the previous match played on the *same field within the
+ * same tournament*. Minutes (rather than seconds) to match the unit already
+ * used by `ScheduleParams.cycleTime`; the `match.cycleTime` column is `REAL`,
+ * so the fractional part is preserved.
+ *
+ * Scoped to the tournament on purpose — a "cycle" spanning the gap between
+ * quals and playoffs is not a number anyone wants to see in a report.
+ *
+ * Ordered by `actualStartTime` rather than by `id` so that matches played out
+ * of schedule order still produce a sane result.
+ *
+ * @returns the cycle time in minutes, or `null` when there is no prior started
+ * match on this field — i.e. the first match of a tournament on a given field
+ * has no cycle time, and the caller should leave the existing value alone
+ * rather than writing a misleading `0`.
+ */
+export const computeCycleTime = async (
+  db: EventDatabase,
+  match: CycleTimeInput
+): Promise<number | null> => {
+  const { eventKey, tournamentKey, id, fieldNumber, actualStartTime } = match;
+  if (!actualStartTime) return null;
+
+  const startedAt = Date.parse(actualStartTime);
+  if (Number.isNaN(startedAt)) return null;
+
+  const [previous] = await db.selectAllWhere(
+    'match',
+    `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" ` +
+      `AND fieldNumber = ${fieldNumber} AND id != ${id} ` +
+      `AND actualStartTime IS NOT NULL AND actualStartTime != '' ` +
+      `AND actualStartTime < "${actualStartTime}" ` +
+      `ORDER BY actualStartTime DESC LIMIT 1`
+  );
+  if (!previous?.actualStartTime) return null;
+
+  const previousStartedAt = Date.parse(previous.actualStartTime);
+  if (Number.isNaN(previousStartedAt)) return null;
+
+  return (startedAt - previousStartedAt) / 1000 / 60;
+};

--- a/apps/services/api/src/util/Webhooks.ts
+++ b/apps/services/api/src/util/Webhooks.ts
@@ -4,28 +4,106 @@ import { getDB } from '../db/EventDatabase.js';
 
 const AbortController = globalThis.AbortController;
 
+/**
+ * Match fields that are owned by the database rather than by the client that
+ * triggered the webhook. These get overlaid onto the payload before it goes
+ * out; see `withPersistedFields`.
+ */
+const PERSISTED_FIELDS = [
+  'name',
+  'scheduledTime',
+  'prestartTime',
+  'actualStartTime',
+  'cycleTime',
+  'fieldNumber',
+  'active',
+  'uploaded'
+] as const;
+
+/**
+ * Overlays the authoritative persisted values for {@link PERSISTED_FIELDS} onto
+ * a client-supplied match payload.
+ *
+ * Webhooks are triggered by the browser, so the payload is whatever that client
+ * happened to be holding — which is how a stale `prestartTime` shipped for a
+ * whole season (#236). Re-reading those fields from the database fixes that.
+ *
+ * This deliberately *overlays* rather than replacing the payload wholesale.
+ * Before scores are committed the database row is the stale one: live scores,
+ * penalties, `result`, participants and details exist only in the realtime
+ * room and on the client. `ALL_CLEAR` in particular fires *before* `COMMITTED`,
+ * so swapping in the database row there would report a match that was just
+ * played as 0-0. Timing/identity metadata comes from the database; live scoring
+ * data stays with the payload.
+ *
+ * Falls back to the payload untouched if the match cannot be read, so a webhook
+ * still goes out rather than being dropped.
+ */
+const withPersistedFields = async (match: Match<any>): Promise<Match<any>> => {
+  try {
+    const db = await getDB(match.eventKey);
+    const [stored] = await db.selectAllWhere(
+      'match',
+      `eventKey = "${match.eventKey}" AND tournamentKey = "${match.tournamentKey}" AND id = ${match.id}`
+    );
+    if (!stored) return match;
+    const overlay: Record<string, unknown> = {};
+    for (const field of PERSISTED_FIELDS) {
+      if (stored[field] !== undefined) overlay[field] = stored[field];
+    }
+    return { ...match, ...overlay };
+  } catch (e) {
+    console.error(
+      `Failed to read persisted fields for webhook payload; sending client payload as-is:`,
+      e
+    );
+    return match;
+  }
+};
+
 export const EmitWebhooks = async (
   webhookEvent: WebhookEvent,
   match: Match<any>
 ) => {
+  // Callers pass whatever is in the client's match atom, which is `null` when
+  // no match is selected. Bail out loudly instead of throwing on
+  // `match.fieldNumber` below and having the route swallow it silently.
+  // eventKey must be non-empty specifically because `getDB` below would
+  // otherwise create a stray database file named after it.
+  if (!match?.eventKey || !match.tournamentKey || match.id === undefined) {
+    console.error(
+      `Refusing to emit ${webhookEvent} webhook: payload is not a match.`,
+      match
+    );
+    return;
+  }
+  const payload = await withPersistedFields(match);
+
   const db = await getDB('global');
   const andClause =
     webhookEvent === WebhookEvent.SCORES_POSTED
       ? `AND subscribedEvent IN ('${WebhookEvent.SCORES_POSTED}', '${WebhookEvent.SCORES_POSTED_RED}', '${WebhookEvent.SCORES_POSTED_BLUE}', '${WebhookEvent.SCORES_POSTED_TIED}')`
       : '';
   const initialClause = webhookEvent === WebhookEvent.SCORES_POSTED ? '' : `subscribedEvent = '${webhookEvent}' AND `;
+  // A webhook with no `field` set is subscribed to every field. If we can't
+  // determine which field this match is on, those all-field subscribers should
+  // still fire — interpolating a non-numeric fieldNumber straight into the SQL
+  // would instead error out and drop the event for everyone.
+  const fieldClause = Number.isFinite(payload.fieldNumber)
+    ? `(field IS NULL OR field = ${payload.fieldNumber})`
+    : 'field IS NULL';
   const webhooks = (await db.selectAllWhere(
     'webhooks',
-    `${initialClause} enabled = 1 AND (field IS NULL OR field = ${match.fieldNumber}) ${andClause}`
+    `${initialClause} enabled = 1 AND ${fieldClause} ${andClause}`
   )) as WebhookDb[];
   for (const webhook of webhooks) {
     if (webhook) {
       let winner: 'RED' | 'BLUE' | 'TIED' | null = null;
       // Calculate the winner
       if (webhookEvent === WebhookEvent.SCORES_POSTED) {
-        if (match.redScore > match.blueScore) {
+        if (payload.redScore > payload.blueScore) {
           winner = 'RED';
-        } else if (match.blueScore > match.redScore) {
+        } else if (payload.blueScore > payload.redScore) {
           winner = 'BLUE';
         } else {
           winner = 'TIED';
@@ -56,7 +134,7 @@ export const EmitWebhooks = async (
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: webhookEvent,
-              payload: match
+              payload
             }),
             signal: controller.signal
           });

--- a/apps/web/src/api/events/match-prestart-event.ts
+++ b/apps/web/src/api/events/match-prestart-event.ts
@@ -46,8 +46,14 @@ export const usePrestartEvent = () => {
       const seasonKey = getSeasonKeyFromEventKey(eventKey);
       const details = getDefaultMatchDetailsBySeasonKey(seasonKey);
       match.details = { eventKey, id, tournamentKey, ...details };
+      // All four penalty counters clear together. Prestart is the first step of
+      // the match cycle, so it is the reset point; penalties and cards awarded
+      // "before the match starts" are awarded after prestart, once the referee
+      // screens have a match loaded, and so are unaffected by this.
       match.redMinPen = 0;
       match.blueMinPen = 0;
+      match.redMajPen = 0;
+      match.blueMajPen = 0;
       match.redScore = 0;
       match.blueScore = 0;
       match.result = -1;

--- a/apps/web/src/apps/audience-display-manager/audience-display-manager.tsx
+++ b/apps/web/src/apps/audience-display-manager/audience-display-manager.tsx
@@ -141,7 +141,6 @@ export const AudienceDisplayManager: FC = () => {
               <TableCell>IP Address</TableCell>
               <TableCell>Connetcted</TableCell>
               <TableCell>Socket ID</TableCell>
-              <TableCell>Last URL</TableCell>
               <TableCell>Chroma Key</TableCell>
               <TableCell>Field Numbers</TableCell>
               <TableCell>Follower Mode Enabled</TableCell>
@@ -160,7 +159,6 @@ export const AudienceDisplayManager: FC = () => {
                 <TableCell>{client.ipAddress}</TableCell>
                 <TableCell>{client.connected ? 'Yes' : 'No'}</TableCell>
                 <TableCell>{client.lastSocketId}</TableCell>
-                <TableCell>{client.currentUrl}</TableCell>
                 <TableCell>
                   {client.audienceDisplayChroma.replaceAll('"', '')}
                 </TableCell>

--- a/apps/web/src/apps/scorekeeper/hooks/use-prestart.ts
+++ b/apps/web/src/apps/scorekeeper/hooks/use-prestart.ts
@@ -78,7 +78,10 @@ export const usePrestartCallback = () => {
         // Send prestart to server
         events.prestart({ eventKey, tournamentKey, id });
         setState(MatchState.PRESTART_COMPLETE);
-        emitWebhook(WebhookEvent.PRESTARTED, match);
+        // `currentMatch`, not `match`: `match` is the pre-patch object, so
+        // sending it here shipped `prestartTime: ''` and `active: 0` to every
+        // subscriber — the original symptom behind issue #236.
+        emitWebhook(WebhookEvent.PRESTARTED, currentMatch);
       },
       [canPrestart, setState, teams]
     )

--- a/apps/web/src/apps/scorekeeper/hooks/use-start-match.ts
+++ b/apps/web/src/apps/scorekeeper/hooks/use-start-match.ts
@@ -6,7 +6,9 @@ import { useModal } from '@ebay/nice-modal-react';
 import { AbortDialog } from 'src/components/dialogs/abort-dialog.js';
 import { useAtomCallback } from 'jotai/utils';
 import { useCallback } from 'react';
+import { DateTime } from 'luxon';
 import { emitWebhook } from 'src/api/use-webhook-data.js';
+import { patchMatch } from 'src/api/use-match-data.js';
 import { matchAtom } from 'src/stores/state/index.js';
 
 export const useMatchStartCallback = () => {
@@ -15,7 +17,7 @@ export const useMatchStartCallback = () => {
   const { events, connected } = useSocketWorker();
   return useAtomCallback(
     useCallback(
-      (get) => {
+      async (get, set) => {
         const match = get(matchAtom);
         if (!connected) {
           throw new Error('Not connected to realtime service.');
@@ -23,12 +25,31 @@ export const useMatchStartCallback = () => {
         if (!canStartMatch) {
           throw new Error('Attempted to start match when not allowed.');
         }
+        if (!match) {
+          throw new Error('Attempted to start match without a match selected.');
+        }
+        // Start the field and the timer first — neither should wait on a
+        // network round trip. Everything below is bookkeeping.
         fieldControl?.startField?.();
         events.start();
         setState(MatchState.MATCH_IN_PROGRESS);
-        emitWebhook(WebhookEvent.MATCH_STARTED, match);
+
+        const currentMatch = {
+          ...match,
+          actualStartTime: DateTime.now().toISO() ?? ''
+        };
+        set(matchAtom, currentMatch);
+        try {
+          await patchMatch(currentMatch);
+        } catch (e) {
+          // Deliberately not rethrown: the match is already running, and
+          // surfacing a blocking error mid-match would be alarming and
+          // unactionable. The start time can be corrected in the match editor.
+          console.error('Failed to persist match start time', e);
+        }
+        emitWebhook(WebhookEvent.MATCH_STARTED, currentMatch);
       },
-      [canStartMatch, setState]
+      [canStartMatch, setState, connected, fieldControl, events]
     )
   );
 };

--- a/libs/models/src/base/Match.ts
+++ b/libs/models/src/base/Match.ts
@@ -105,7 +105,12 @@ export type Match<T extends MatchDetailBase> = {
   name: string;
   scheduledTime: string;
   prestartTime: string;
-  startTime: string;
+  /**
+   * When the match actually started, as an ISO string. Distinct from
+   * `scheduledTime` (when the schedule says it should start) — this is only
+   * written once the match is actually started, and is `''` until then.
+   */
+  actualStartTime: string;
   fieldNumber: number;
   cycleTime: number;
   redScore: number;
@@ -129,7 +134,7 @@ export const matchZod: z.ZodSchema<Match<MatchDetailBase>> = z.object({
   name: z.string(),
   scheduledTime: z.string(),
   prestartTime: z.string(),
-  startTime: z.string(),
+  actualStartTime: z.string(),
   cycleTime: z.number(),
   redScore: z.number(),
   redMinPen: z.number(),
@@ -199,7 +204,10 @@ export function createFixedMatches(
       redMinPen: 0,
       redScore: 0,
       scheduledTime: item.startTime,
-      startTime: item.startTime,
+      // Seeded empty, not from `item.startTime`: the schedule item's start time
+      // is when the match is *supposed* to start. It gets filled in when the
+      // match is actually started.
+      actualStartTime: '',
       uploaded: 0
     };
     const matchAllianceMap = matchMap[matchNumber];

--- a/libs/server/src/MatchMaker.ts
+++ b/libs/server/src/MatchMaker.ts
@@ -80,7 +80,7 @@ function parseMatchMaker(
       redMinPen: 0,
       redScore: 0,
       scheduledTime: '',
-      startTime: '',
+      actualStartTime: '',
       uploaded: 0,
       participants
     });


### PR DESCRIPTION
Closes audit findings **#1, #2, #3, #6, #7, #8** of #236. First of four stacked PRs; review/merge in order.

> **⚠️ Breaking for API/webhook consumers:** `Match.startTime` is now `Match.actualStartTime`, and `socket_clients.currentUrl` is gone from responses. Both were misleading or never populated, so nothing that worked stops working — but the key names change on the wire.

## `Match.startTime` → `Match.actualStartTime`, and actually populate it

The old name promised "when the match started" and held a schedule value. MatchMaker seeded `''`, `createFixedMatches` copied the schedule item's start time, and nothing ever wrote it when a match actually started. It's now set in `useMatchStartCallback`, after the field and timer fire so nothing waits on a network round trip.

There are no UI readers of `match.startTime` — the many other `startTime` hits belong to `ScheduleItem`/`Day`/`DayBreak` and are untouched. The rename is type-visible, so a missed reader fails the build.

## Schema migrations now reach existing databases

Every `create_*.sql` is `CREATE TABLE IF NOT EXISTS`, so a schema change only ever reaches *new* databases. An existing event DB would have kept its `startTime` column and silently dropped every write to `actualStartTime`.

Adds an idempotent `EventDatabase.runMigrations()` that performs the rename on open, no-ops on repeat, and is safe on a database with no tables yet. It's deliberately a general, named seam — every future column change needs it.

## `Match.cycleTime` was always `0`

Now derived server-side in `PATCH /match/:e/:t/:id` via `computeCycleTime()`: fractional minutes between consecutive match starts on the same field within the same tournament. Ordered by `actualStartTime` rather than `id` so out-of-order play still gives a sane number, and returns `null` for the first match on a field rather than writing a misleading `0`.

> Units/definition are a judgement call — minutes matches `ScheduleParams.cycleTime` and the column is already `REAL`. The alternative reading (prestart → results-posted for one match) is a one-line change in the helper.

## Webhook payloads are now authoritative

Two bugs. The `PRESTARTED` emit passed the **pre-patch** match object, so every subscriber received `prestartTime: ''` and `active: 0` — the original #236 symptom. And a `null` match atom threw inside `EmitWebhooks`, where the route swallowed it and the webhook silently never fired.

`EmitWebhooks` now refuses a non-match payload loudly, and overlays DB-owned timing/identity fields onto the client payload.

**It overlays rather than replaces, deliberately.** Pre-commit the DB row is the stale one — live scores, penalties, `result`, participants and details exist only in the realtime room and on the client. `ALL_CLEAR` fires *before* `COMMITTED`, so a wholesale DB read would report a just-played match as 0-0.

## Also

- Reset `redMajPen`/`blueMajPen` at prestart, so all four penalty counters clear together. Prestart is the first step of the cycle; cards and penalties awarded "before the match starts" are awarded *after* prestart, once referee screens have a match loaded.
- Drop `socket_clients.currentUrl` — nothing ever wrote it, yet the display manager rendered it.
- Add `ipAddress` to the socket client response schema. It was written on connect but omitted from the schema, so the zod serializer stripped it and the UI's IP column was blank on every row.

## Verification

Full turbo build green. Beyond typechecking, exercised against real SQLite / real routes:

- **Migration** — seeded a DB with the pre-rename schema: column renamed, row values intact, second open a clean no-op, table-less DB unaffected.
- **`computeCycleTime`** — 6 cases: field isolation, tournament isolation, first-match-returns-null, out-of-order play, empty start time.
- **Webhook overlay (the #236 acceptance test)** — sent a deliberately stale payload (`prestartTime: ''`, `active: 0`) and confirmed delivery carried the DB's `prestartTime`/`active`/`cycleTime`/`name`/`scheduledTime` **while preserving the client's live scores, penalties and participants**. Plus null payload refused without throwing.
