### PR TITLE
Emit the three webhook events that never fired

### DIFF
--- a/apps/web/src/apps/scorekeeper/hooks/use-match-lifecycle-webhooks.ts
+++ b/apps/web/src/apps/scorekeeper/hooks/use-match-lifecycle-webhooks.ts
@@ -1,0 +1,59 @@
+import { MatchSocketEvent, WebhookEvent } from '@toa-lib/models';
+import { useAtomCallback } from 'jotai/utils';
+import { useCallback, useEffect, useMemo } from 'react';
+import { proxy } from 'comlink';
+import { emitWebhook } from 'src/api/use-webhook-data.js';
+import { useSocketWorker } from 'src/api/use-socket-worker.js';
+import { matchAtom } from 'src/stores/state/event.js';
+
+/**
+ * Emits the two webhooks that are driven by the match timer rather than by an
+ * operator action: `MATCH_ENDGAME` and `MATCH_ENDED`.
+ *
+ * Every other webhook is emitted from the scorekeeper control that causes it
+ * (prestart, set displays, prep field, commit, post). These two have no such
+ * control — the realtime room broadcasts them off its own timer — so they need
+ * a socket subscriber instead.
+ *
+ * Mounted from `ScorekeeperApp` rather than from `ConnectionManager`, which is
+ * where the app already subscribes to these same events. `ConnectionManager`
+ * lives in `App.tsx` and therefore runs in *every* open tab — audience
+ * displays, referee tablets, field monitors — so emitting from there would
+ * send one webhook per open tab. Scoping to the scorekeeper gives the same
+ * one-emit-per-event behavior the other seven webhooks already rely on.
+ *
+ * Note this shares their caveat: two scorekeeper tabs open on the same event
+ * will double-emit, exactly as they would for `PRESTARTED` today.
+ */
+export const useMatchLifecycleWebhooks = () => {
+  const { worker, connected } = useSocketWorker();
+
+  const emitForCurrentMatch = useAtomCallback(
+    useCallback((get, _set, event: WebhookEvent) => {
+      const match = get(matchAtom);
+      // EmitWebhooks refuses a non-match payload, but there is no point making
+      // the round trip when no match is loaded.
+      if (!match) return;
+      emitWebhook(event, match);
+    }, [])
+  );
+
+  const endgameProxy = useMemo(
+    () => proxy(() => emitForCurrentMatch(WebhookEvent.MATCH_ENDGAME)),
+    [emitForCurrentMatch]
+  );
+  const endProxy = useMemo(
+    () => proxy(() => emitForCurrentMatch(WebhookEvent.MATCH_ENDED)),
+    [emitForCurrentMatch]
+  );
+
+  useEffect(() => {
+    if (!worker || !connected) return;
+    worker.on(MatchSocketEvent.ENDGAME, endgameProxy);
+    worker.on(MatchSocketEvent.END, endProxy);
+    return () => {
+      worker.off(MatchSocketEvent.ENDGAME, endgameProxy);
+      worker.off(MatchSocketEvent.END, endProxy);
+    };
+  }, [worker, connected, endgameProxy, endProxy]);
+};

--- a/apps/web/src/apps/scorekeeper/hooks/use-prestart.ts
+++ b/apps/web/src/apps/scorekeeper/hooks/use-prestart.ts
@@ -91,11 +91,18 @@ export const usePrestartCallback = () => {
 export const useCancelPrestartCallback = () => {
   const { canCancelPrestart, setState } = useMatchControl();
   const fieldControl = useSeasonFieldControl();
-  return useCallback(() => {
-    if (!canCancelPrestart) {
-      throw new Error('Attempted to cancel prestart when not allowed.');
-    }
-    fieldControl?.cancelPrestartForField?.();
-    setState(MatchState.PRESTART_READY);
-  }, [canCancelPrestart, setState, fieldControl]);
+  return useAtomCallback(
+    useCallback(
+      (get) => {
+        if (!canCancelPrestart) {
+          throw new Error('Attempted to cancel prestart when not allowed.');
+        }
+        const match = get(matchAtom);
+        fieldControl?.cancelPrestartForField?.();
+        setState(MatchState.PRESTART_READY);
+        if (match) emitWebhook(WebhookEvent.PRESTART_ABORTED, match);
+      },
+      [canCancelPrestart, setState, fieldControl]
+    )
+  );
 };

--- a/apps/web/src/apps/scorekeeper/hooks/use-start-match.ts
+++ b/apps/web/src/apps/scorekeeper/hooks/use-start-match.ts
@@ -59,14 +59,23 @@ export const useAbortMatchCallback = () => {
   const abortModal = useModal(AbortDialog);
   const fieldControl = useSeasonFieldControl();
   const { events } = useSocketWorker();
-  return async () => {
-    if (!canAbortMatch) {
-      throw new Error('Attempted to abort match when not allowed.');
-    }
-    const canAbort = await abortModal.show();
-    if (!canAbort) return;
-    fieldControl?.abortField?.();
-    events.abort();
-    setState(MatchState.PRESTART_READY);
-  };
+  return useAtomCallback(
+    useCallback(
+      async (get) => {
+        if (!canAbortMatch) {
+          throw new Error('Attempted to abort match when not allowed.');
+        }
+        const canAbort = await abortModal.show();
+        if (!canAbort) return;
+        const match = get(matchAtom);
+        fieldControl?.abortField?.();
+        events.abort();
+        setState(MatchState.PRESTART_READY);
+        // Aborting returns the field to PRESTART_READY, so from a subscriber's
+        // point of view the prestart has been undone — same as cancelling it.
+        if (match) emitWebhook(WebhookEvent.PRESTART_ABORTED, match);
+      },
+      [canAbortMatch, setState, fieldControl, events, abortModal]
+    )
+  );
 };

--- a/apps/web/src/apps/scorekeeper/scorekeeper-app.tsx
+++ b/apps/web/src/apps/scorekeeper/scorekeeper-app.tsx
@@ -6,6 +6,7 @@ import { MatchHeader } from './match-header/match-header.js';
 import { Row } from 'antd';
 import { useEventState } from 'src/stores/hooks/use-event-state.js';
 import { PageLoader } from 'src/components/loading/page-loader.js';
+import { useMatchLifecycleWebhooks } from './hooks/use-match-lifecycle-webhooks.js';
 
 export const ScorekeeperApp: FC = () => {
   const {
@@ -14,6 +15,9 @@ export const ScorekeeperApp: FC = () => {
       local: { event, teams }
     }
   } = useEventState({ event: true, teams: true });
+
+  // Scoped here rather than to ConnectionManager on purpose; see the hook.
+  useMatchLifecycleWebhooks();
 
   if (loading) {
     return <PageLoader />;

--- a/libs/models/src/base/Webhook.ts
+++ b/libs/models/src/base/Webhook.ts
@@ -1,20 +1,31 @@
 import { z } from 'zod';
 import { matchZod } from './Match.js';
 
+/**
+ * Events a webhook can be subscribed to. Every payload is `{ payload: Match }`.
+ *
+ * The first group is emitted directly. The `SCORES_POSTED_*` variants are
+ * **subscription-side filters**, not separate emits: only `SCORES_POSTED` is
+ * ever emitted, and `EmitWebhooks` decides the winner and delivers to whichever
+ * of the coloured subscriptions matches. Subscribing to `SCORES_POSTED` itself
+ * receives every posted result regardless of outcome.
+ */
 export enum WebhookEvent {
-  PRESTARTED = 'PRESTARTED', // { payload: Match }
-  PRESTART_ABORTED = 'PRESTART_ABORTED', // { payload: Match }
-  DISPLAYS_SET = 'DISPLAYS_SET', // { payload: Match }
-  FIELD_PREPPED = 'FIELD_PREPPED', // { payload: Match }
-  MATCH_STARTED = 'MATCH_STARTED', // { payload: Match }
-  MATCH_ENDGAME = 'MATCH_ENDGAME', // { payload: Match }
-  MATCH_ENDED = 'MATCH_ENDED', // { payload: Match }
-  ALL_CLEAR = 'ALL_CLEAR', // { payload: Match }
-  COMMITTED = 'COMMITTED', // { payload: Match }
-  SCORES_POSTED = 'SCORES_POSTED', // { payload: Match }
-  SCORES_POSTED_RED = 'SCORES_POSTED_RED', // { payload: Match }
-  SCORES_POSTED_BLUE = 'SCORES_POSTED_BLUE', // { payload: Match }
-  SCORES_POSTED_TIED = 'SCORES_POSTED_TIED' // { payload: Match }
+  PRESTARTED = 'PRESTARTED',
+  PRESTART_ABORTED = 'PRESTART_ABORTED',
+  DISPLAYS_SET = 'DISPLAYS_SET',
+  FIELD_PREPPED = 'FIELD_PREPPED',
+  MATCH_STARTED = 'MATCH_STARTED',
+  MATCH_ENDGAME = 'MATCH_ENDGAME',
+  MATCH_ENDED = 'MATCH_ENDED',
+  ALL_CLEAR = 'ALL_CLEAR',
+  COMMITTED = 'COMMITTED',
+  SCORES_POSTED = 'SCORES_POSTED',
+
+  // Filters on SCORES_POSTED — see above. Never emitted on their own.
+  SCORES_POSTED_RED = 'SCORES_POSTED_RED',
+  SCORES_POSTED_BLUE = 'SCORES_POSTED_BLUE',
+  SCORES_POSTED_TIED = 'SCORES_POSTED_TIED'
 };
 
 export const SendWebhookSchema = z.object({


### PR DESCRIPTION
Closes audit finding **#10** of #236. Second of four stacked PRs — **based on #255**, review/merge after it.

## The problem

The settings dropdown enumerates all 13 `WebhookEvent` values, but only 7 were ever emitted. Subscribing to `PRESTART_ABORTED`, `MATCH_ENDGAME` or `MATCH_ENDED` silently produced nothing, forever.

## `PRESTART_ABORTED`

Emitted from both operator paths that undo a prestart: cancelling it outright (`useCancelPrestartCallback`), and aborting a running match (`useAbortMatchCallback`) — which also returns the field to `PRESTART_READY`, so subscribers see the same transition either way.

## `MATCH_ENDGAME` / `MATCH_ENDED`

These have no operator control behind them — the realtime room broadcasts them off its own timer — so they need a socket subscriber rather than a button handler.

**That subscriber is scoped to `ScorekeeperApp`, not added to `ConnectionManager`**, even though `ConnectionManager` already listens for these exact events. It's mounted in `App.tsx`, so it runs in *every* open tab: emitting from there would send one webhook per audience display, referee tablet and field monitor. Scoping to the scorekeeper gives the same one-emit-per-event behaviour the other seven webhooks already rely on.

It inherits their caveat too, and the hook says so: two scorekeeper tabs open on one event will double-emit, exactly as they would for `PRESTARTED` today.

> The strictly-correct fix is emitting server-side from the realtime service, which is the true single source for timer events. That needs a new API-URL config threaded through docker-compose, ecosystem.config.js and amplify — a silent-breakage risk for a live event if unset — so it's deliberately not done here.

Both new emits inherit #255's DB overlay automatically, since they go through `emitWebhook`.

## Also

Documents `SCORES_POSTED_RED`/`_BLUE`/`_TIED` as **subscription-side filters** on `SCORES_POSTED` rather than independent emits. That was correct by design but undocumented, and reads at a glance like three more dead events.

## Verification

Full turbo build green. All 10 emittable events now have emit sites; the only three without are the subscription-side filters above, by design.
