### PR TITLE
Carry yellow cards forward within a tournament phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ out/
 .amplify
 amplify_outputs*
 amplifyconfiguration*
+logs/

--- a/apps/services/api/sql/create_event.sql
+++ b/apps/services/api/sql/create_event.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS "team" (
     "countryCode" VARCHAR(2),
     "rookieYear" INT,
     "cardStatus" INT,
+    "cardPhase" VARCHAR(15),
     PRIMARY KEY (eventKey, teamKey),
     UNIQUE (eventKey, teamKey)
 );

--- a/apps/services/api/src/controllers/Match.ts
+++ b/apps/services/api/src/controllers/Match.ts
@@ -5,7 +5,8 @@ import {
   matchMakerParamsZod,
   matchParticipantZod,
   reconcileMatchParticipants,
-  getFunctionsBySeasonKey
+  getFunctionsBySeasonKey,
+  getCardCarryPhase
 } from '@toa-lib/models';
 import { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
@@ -212,12 +213,28 @@ async function matchController(fastify: FastifyInstance) {
         const parsedDetails = funcs?.detailsFromJson
           ? (funcs.detailsFromJson(details) ?? details)
           : details;
+        // A carried card is only in force during the phase it was earned in, so
+        // it is scoped here rather than at every display. This route is the
+        // authoritative source of `participant.team` for the audience display
+        // and the scorekeeper's repeat-card prompt, and unlike them it knows
+        // which tournament is being played. Prestarting the first match of a
+        // new phase therefore "resets" the cards with no reset step to run.
+        const [tournament] = await db.selectAllWhere(
+          'tournament',
+          `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}"`
+        );
+        const phase = tournament ? getCardCarryPhase(tournament) : null;
         for (let i = 0; i < participants.length; i++) {
           const [team] = await db.selectAllWhere(
             'team',
             `teamKey = ${participants[i].teamKey} AND eventKey = "${eventKey}"`
           );
-          participants[i].team = team;
+          // A null phase (test/practice) matches nothing, which is what makes
+          // carried cards invisible there.
+          participants[i].team =
+            team && team.cardPhase && team.cardPhase === phase
+              ? team
+              : { ...team, cardStatus: 0, hasCard: 0, cardPhase: null };
         }
         match.participants = participants;
         match.details = parsedDetails;

--- a/apps/services/api/src/controllers/Team.ts
+++ b/apps/services/api/src/controllers/Team.ts
@@ -3,10 +3,14 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { getDB } from '../db/EventDatabase.js';
 import { z } from 'zod';
 import { DataNotFoundError, errorableSchema, InternalServerError } from '../util/Errors.js';
-import { teamZod } from '@toa-lib/models';
-import { EventKeyParams, EmptySchema, EventTeamKeyParams } from '../util/GlobalSchema.js';
+import { CardStatus, getCardCarryPhase, teamZod } from '@toa-lib/models';
+import { EventKeyParams, EmptySchema, EventTeamKeyParams, EventTournamentKeyParams } from '../util/GlobalSchema.js';
 
 const teamsZod = z.array(teamZod);
+
+const carryCardsZod = z.array(
+  z.object({ teamKey: z.number(), cardStatus: z.number() })
+);
 
 async function teamController(fastify: FastifyInstance) {
   // Get all teams (global)
@@ -38,6 +42,85 @@ async function teamController(fastify: FastifyInstance) {
         } else {
           reply.send(data);
         }
+      } catch (e) {
+        reply.code(500).send(InternalServerError(e));
+      }
+    }
+  );
+
+  // Promote match cards onto the carrying team for the rest of the *phase*.
+  //
+  // A card carries through qualification, or through playoffs, but never across
+  // the boundary between them — see getCardCarryPhase. The phase is derived
+  // server-side from the tournament rather than accepted from the caller, so
+  // the rule has one definition and clients cannot disagree about it.
+  //
+  // Clearing rules, which are narrower than they look:
+  //  - A card for the *current* phase is never cleared here. A later clean
+  //    match, or a replay, must not drop one; that stays a manual act via the
+  //    Carried Card control in the team editor.
+  //  - A card from a *previous* phase is cleared, because it is already spent.
+  //    Read paths scope validity by phase anyway, so this is housekeeping to
+  //    keep GET /teams honest rather than something correctness depends on.
+  //
+  // Only YELLOW_CARD carries. Reds and whites are per-match rulings and are
+  // left on the match participant, and a team already carrying a yellow is not
+  // escalated to a red by receiving another — that is a human decision, which
+  // is what the scorekeeper's "consult with HR" prompt is for.
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/carry-cards/:eventKey/:tournamentKey',
+    {
+      schema: {
+        params: EventTournamentKeyParams,
+        body: carryCardsZod,
+        response: errorableSchema<typeof EmptySchema>(EmptySchema),
+        tags: ['Teams']
+      }
+    },
+    async (request, reply) => {
+      try {
+        const { eventKey, tournamentKey } = request.params as z.infer<
+          typeof EventTournamentKeyParams
+        >;
+        const db = await getDB(eventKey);
+        const [tournament] = await db.selectAllWhere(
+          'tournament',
+          `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}"`
+        );
+        const phase = tournament ? getCardCarryPhase(tournament) : null;
+
+        // Test and practice cards go nowhere. Note this returns *before* the
+        // stale-phase cleanup below: a practice tournament run between quals
+        // and playoffs must not wipe cards teams are legitimately carrying.
+        if (!phase) {
+          reply.status(200).send({});
+          return;
+        }
+
+        // Drop cards left over from a phase that is now finished.
+        await db.updateWhere(
+          'team',
+          { cardStatus: CardStatus.NO_CARD, hasCard: 0, cardPhase: null },
+          `eventKey = "${eventKey}" AND cardPhase IS NOT NULL AND cardPhase != "${phase}"`
+        );
+
+        for (const { teamKey, cardStatus } of request.body) {
+          if (cardStatus !== CardStatus.YELLOW_CARD) continue;
+          // Guarding on "no card *for this phase*" keeps this idempotent — a
+          // team already carrying one is left exactly as it is.
+          await db.updateWhere(
+            'team',
+            {
+              cardStatus: CardStatus.YELLOW_CARD,
+              hasCard: 1,
+              cardPhase: phase
+            },
+            `eventKey = "${eventKey}" AND teamKey = ${teamKey} ` +
+              `AND (cardPhase IS NULL OR cardPhase != "${phase}" ` +
+              `OR cardStatus IS NULL OR cardStatus = ${CardStatus.NO_CARD})`
+          );
+        }
+        reply.status(200).send({});
       } catch (e) {
         reply.code(500).send(InternalServerError(e));
       }

--- a/apps/services/api/src/db/EventDatabase.ts
+++ b/apps/services/api/src/db/EventDatabase.ts
@@ -75,6 +75,9 @@ export class EventDatabase {
     // startTime -> actualStartTime. The old name read like "when the match
     // started" but actually held the scheduled time; see issue #236.
     await this.renameColumnIfPresent('match', 'startTime', 'actualStartTime');
+    // Carried cards are scoped to a qualification/playoff phase rather than to
+    // the whole event; this records which phase a team's card belongs to.
+    await this.addColumnIfMissing('team', 'cardPhase', 'VARCHAR(15)');
   }
 
   /**
@@ -89,10 +92,7 @@ export class EventDatabase {
   ): Promise<void> {
     try {
       if (!(await this.tableExists(table))) return;
-      const columns = (await this.db.all(
-        `PRAGMA table_info("${table}");`
-      )) as { name: string }[];
-      const names = columns.map((c) => c.name);
+      const names = await this.columnNames(table);
       if (!names.includes(from) || names.includes(to)) return;
       await this.db.exec(
         `ALTER TABLE "${table}" RENAME COLUMN "${from}" TO "${to}";`
@@ -100,6 +100,34 @@ export class EventDatabase {
     } catch (e) {
       throw new ApiDatabaseError(table, e);
     }
+  }
+
+  /**
+   * Adds `column` to `table`, but only if the table exists and does not already
+   * have it. `type` is the column's DDL (e.g. `'VARCHAR(15)'`); it must be
+   * nullable or carry a default, since existing rows will need a value.
+   */
+  private async addColumnIfMissing(
+    table: string,
+    column: string,
+    type: string
+  ): Promise<void> {
+    try {
+      if (!(await this.tableExists(table))) return;
+      if (await this.columnNames(table).then((n) => n.includes(column))) return;
+      await this.db.exec(
+        `ALTER TABLE "${table}" ADD COLUMN "${column}" ${type};`
+      );
+    } catch (e) {
+      throw new ApiDatabaseError(table, e);
+    }
+  }
+
+  private async columnNames(table: string): Promise<string[]> {
+    const columns = (await this.db.all(
+      `PRAGMA table_info("${table}");`
+    )) as { name: string }[];
+    return columns.map((c) => c.name);
   }
 
   private async tableExists(table: string): Promise<boolean> {

--- a/apps/web/src/api/use-team-data.ts
+++ b/apps/web/src/api/use-team-data.ts
@@ -20,6 +20,23 @@ export const patchTeam = async (
 export const deleteTeam = async (team: Team): Promise<void> =>
   apiFetcher(`teams/${team.eventKey}/${team.teamKey}`, `DELETE`, team);
 
+/**
+ * Promotes yellow cards issued in a match onto the teams that received them, so
+ * they carry for the rest of the qualification or playoff phase.
+ *
+ * The tournament is passed rather than a phase: the server derives the phase
+ * from it, so the carry rule has one definition. Entries that are not a yellow
+ * are ignored and a team already carrying a card for this phase is untouched,
+ * so this is safe to call with every participant of a match rather than
+ * pre-filtering. Cards from test and practice tournaments are dropped entirely.
+ */
+export const postCarriedCards = async (
+  eventKey: string,
+  tournamentKey: string,
+  cards: { teamKey: number; cardStatus: number }[]
+): Promise<void> =>
+  apiFetcher(`teams/carry-cards/${eventKey}/${tournamentKey}`, 'POST', cards);
+
 export const useTeams = (): SWRResponse<Team[], ApiResponseError> =>
   useSWR('teams', (url) => apiFetcher(url, 'GET'));
 

--- a/apps/web/src/apps/audience-display/displays/seasons/fgc_default_v2/components/alliance-team.tsx
+++ b/apps/web/src/apps/audience-display/displays/seasons/fgc_default_v2/components/alliance-team.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MatchParticipant, Ranking } from '@toa-lib/models';
 import { CountryFlag } from './country-flag.js';
 import { CardStatus } from './card-status.js';
+import { CarriedCard } from './carried-card.js';
 import { Space, Typography } from 'antd';
 import { useAtomValue } from 'jotai';
 import { matchOccurringRanksAtom } from 'src/stores/state/event.js';
@@ -77,6 +78,8 @@ const AllianceTeam: React.FC<AllianceTeamProps> = ({
         }}
       >
         <CardStatus cardStatus={team.cardStatus} />
+        {/* Carried from an earlier match; see CarriedCard. */}
+        <CarriedCard cardStatus={team.team?.cardStatus} />
       </div>
       {!hideRanks && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -154,6 +157,10 @@ export const AllianceTeamStream: React.FC<AllianceTeamProps> = ({
             <CardStatus cardStatus={team.cardStatus} />
           </div>
         )}
+        {/* Carried from an earlier match; see CarriedCard. */}
+        <div style={{ width: '1rem', height: '1rem' }}>
+          <CarriedCard cardStatus={team.team?.cardStatus} />
+        </div>
         <Typography.Text
           style={{ color: 'white', fontWeight: 'bold', fontSize: '1.25rem' }}
         >

--- a/apps/web/src/apps/audience-display/displays/seasons/fgc_default_v2/components/carried-card.tsx
+++ b/apps/web/src/apps/audience-display/displays/seasons/fgc_default_v2/components/carried-card.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import styled from '@emotion/styled';
+import { CardStatus } from '@toa-lib/models';
+import YELLOW_CARD from '../assets/penalty-yellow-card.png';
+
+/**
+ * Marks a team that is *carrying* a card from earlier in the event, as opposed
+ * to one issued in the match currently on screen.
+ *
+ * Rendered separately from `<CardStatus />`, and never merged into it, for two
+ * reasons. Visually, the audience needs to tell "was carded just now" from
+ * "came into this match already carded" — hence the dimmed, outlined
+ * treatment. Structurally, the carried card lives on `Team` while the
+ * per-match card lives on `MatchParticipant`; folding one into the other is
+ * exactly what would let a carried card leak into referee screens and scoring.
+ */
+const Ghost = styled.img`
+  max-height: 100%;
+  width: auto;
+  opacity: 0.55;
+  filter: grayscale(0.25);
+`;
+
+export const CarriedCard: FC<{ cardStatus?: number }> = ({ cardStatus }) => {
+  if (cardStatus !== CardStatus.YELLOW_CARD) return null;
+  return (
+    <Ghost
+      src={YELLOW_CARD}
+      className='fit-h'
+      title='Carrying a yellow card from an earlier match'
+    />
+  );
+};

--- a/apps/web/src/apps/scorekeeper/hooks/use-commit-scores.ts
+++ b/apps/web/src/apps/scorekeeper/hooks/use-commit-scores.ts
@@ -1,6 +1,8 @@
 import { useAtomValue } from 'jotai';
+import { useModal } from '@ebay/nice-modal-react';
 import { useMatchControl } from './use-match-control.js';
 import {
+  CardStatus,
   isPlayoffsTournament,
   MatchState,
   RESULT_BLUE_WIN,
@@ -9,6 +11,8 @@ import {
   RESULT_TIE,
   WebhookEvent
 } from '@toa-lib/models';
+import { CarriedCardDialog } from 'src/components/dialogs/carried-card-dialog.js';
+import { postCarriedCards } from 'src/api/use-team-data.js';
 import {
   patchWholeMatch,
   useMatchesForTournament
@@ -34,6 +38,7 @@ export const useCommitScoresCallback = () => {
   const { data: tournMatches, mutate: updateTournMatches } =
     useMatchesForTournament(eventKey, tournament?.tournamentKey);
   const { events, connected } = useSocketWorker();
+  const carriedCardDialog = useModal(CarriedCardDialog);
 
   return useAtomCallback(
     useCallback(
@@ -53,6 +58,24 @@ export const useCommitScoresCallback = () => {
         if (!match) {
           throw new Error('Attempted to commit scores when there is no match.');
         }
+        // A team picking up a yellow while already carrying one is a human
+        // judgement call, not something to automate — EMS deliberately does not
+        // escalate it to a red. Prompt before the commit so the scores can
+        // still be corrected if HR rules differently.
+        const repeatOffenders = (match.participants ?? []).filter(
+          (p) =>
+            p.cardStatus === CardStatus.YELLOW_CARD &&
+            p.team?.cardStatus === CardStatus.YELLOW_CARD
+        );
+        if (repeatOffenders.length > 0) {
+          const proceed = await carriedCardDialog.show({
+            teams: repeatOffenders.map(
+              (p) => p.team?.teamNameShort ?? `Team ${p.teamKey}`
+            )
+          });
+          if (!proceed) return;
+        }
+
         const pending = { ...match, details: { ...match.details }, active: 0 };
         // Update the result if it hasn't been set yet
         if (pending.result < 0) {
@@ -94,6 +117,24 @@ export const useCommitScoresCallback = () => {
           throw new Error('Failed to calculate rankings.', { cause: e });
         }
 
+        // Carry any yellow cards from this match forward for the rest of the
+        // phase. Only after the match itself has been committed, so a failed
+        // commit never leaves a team carrying a card for a match that was not
+        // recorded. Not rethrown: the scores are already saved, and a carried
+        // card is advisory display state that can be set by hand.
+        try {
+          await postCarriedCards(
+            eventKey,
+            tournamentKey,
+            (pending.participants ?? []).map((p) => ({
+              teamKey: p.teamKey,
+              cardStatus: p.cardStatus
+            }))
+          );
+        } catch (e) {
+          console.error('Failed to carry cards forward for match', e);
+        }
+
         fieldControl?.commitScoresForField?.();
         events.commit({ eventKey, tournamentKey, id });
         setState(MatchState.RESULTS_COMMITTED);
@@ -122,7 +163,14 @@ export const useCommitScoresCallback = () => {
 
         emitWebhook(WebhookEvent.COMMITTED, pending);
       },
-      [canCommitScores, setState, eventKey, tournament, tournMatches]
+      [
+        canCommitScores,
+        setState,
+        eventKey,
+        tournament,
+        tournMatches,
+        carriedCardDialog
+      ]
     )
   );
 };

--- a/apps/web/src/apps/scorekeeper/hooks/use-prestart.ts
+++ b/apps/web/src/apps/scorekeeper/hooks/use-prestart.ts
@@ -44,10 +44,18 @@ export const usePrestartCallback = () => {
         let currentMatch = { ...match, prestartTime, active: 1 };
         await patchMatch(currentMatch);
 
-        currentMatch.participants = currentMatch.participants?.map((p) => ({
-          ...p,
-          team: p.team || teams?.find((t) => t.teamKey === p.teamKey)
-        }));
+        currentMatch.participants = currentMatch.participants?.map((p) => {
+          if (p.team) return p;
+          const team = teams?.find((t) => t.teamKey === p.teamKey);
+          // teamsAtom comes from GET /teams, which has no tournament context and
+          // so reports carried cards unscoped. Strip them here rather than
+          // briefly showing a card from a finished phase — the socket prestart
+          // handler refetches from match/all, which scopes them properly.
+          return {
+            ...p,
+            team: team && { ...team, cardStatus: 0, hasCard: false, cardPhase: null }
+          };
+        });
 
         await patchMatchParticipants(
           { eventKey, tournamentKey, id },

--- a/apps/web/src/components/dialogs/carried-card-dialog.tsx
+++ b/apps/web/src/components/dialogs/carried-card-dialog.tsx
@@ -1,0 +1,57 @@
+import { Modal, Button } from 'antd';
+import { create, useModal } from '@ebay/nice-modal-react';
+
+interface CarriedCardDialogProps {
+  /** Display names of the teams receiving a yellow while already carrying one. */
+  teams: string[];
+}
+
+/**
+ * Shown at commit time when a team that is already carrying a yellow card
+ * receives another one in the match being committed.
+ *
+ * This is purely advisory. EMS does not escalate a second yellow to a red —
+ * that call belongs to a human, which is the entire point of the prompt.
+ * Cancelling aborts the commit so the scores can be corrected first.
+ */
+export const CarriedCardDialog = create<CarriedCardDialogProps>(({ teams }) => {
+  const modal = useModal();
+
+  const handleContinue = () => {
+    modal.resolve(true);
+    modal.hide();
+  };
+
+  const handleClose = () => {
+    modal.resolve(false);
+    modal.hide();
+  };
+
+  return (
+    <Modal
+      open={modal.visible}
+      onCancel={handleClose}
+      title='Repeat Yellow Card'
+      footer={[
+        <Button key='continue' type='primary' danger onClick={handleContinue}>
+          Commit Anyway
+        </Button>,
+        <Button key='cancel' onClick={handleClose}>
+          Cancel
+        </Button>
+      ]}
+      destroyOnClose
+    >
+      <p>
+        {teams.length === 1
+          ? `${teams[0]} received a yellow card this match and was already carrying one.`
+          : `The following teams received a yellow card this match and were already carrying one: ${teams.join(
+              ', '
+            )}.`}
+      </p>
+      <p>
+        <strong>Consult with HR</strong> before committing these scores.
+      </p>
+    </Modal>
+  );
+});

--- a/apps/web/src/components/forms/team-form.tsx
+++ b/apps/web/src/components/forms/team-form.tsx
@@ -1,6 +1,6 @@
 import { FC, ChangeEvent, useState, useEffect } from 'react';
-import { Button, Form, Input, InputNumber, Row, Col } from 'antd';
-import { Team, defaultTeam } from '@toa-lib/models';
+import { Button, Form, Input, InputNumber, Row, Col, Select } from 'antd';
+import { CardStatus, Team, defaultTeam } from '@toa-lib/models';
 import { ViewReturn } from '@components/buttons/view-return.js';
 
 const FormField: FC<{
@@ -53,6 +53,20 @@ export const TeamForm: FC<Props> = ({
     setTeam({
       ...team,
       [name]: type === 'number' ? parseInt(value) : value
+    });
+  };
+
+  // hasCard mirrors cardStatus and cardPhase records which phase the card is in
+  // force for, so all three are always written together. Clearing the card
+  // clears the phase; setting one by hand here has no tournament context, so it
+  // keeps whatever phase was already recorded.
+  const handleCardStatusChange = (cardStatus: number) => {
+    const cleared = cardStatus === CardStatus.NO_CARD;
+    setTeam({
+      ...team,
+      cardStatus,
+      hasCard: !cleared,
+      cardPhase: cleared ? null : team.cardPhase
     });
   };
 
@@ -130,6 +144,36 @@ export const TeamForm: FC<Props> = ({
           onChange={handleChange}
           disabled={loading}
         />
+        {/*
+          Carried cards are only ever *set* automatically (a yellow issued in a
+          match carries for the rest of the event). Nothing clears one
+          automatically, so that a card cannot be dropped as a side effect of a
+          later match being played or replayed — this control is the way back.
+        */}
+        <Col xs={24} sm={12} md={8}>
+          <Form.Item
+            label='Carried Card'
+            // The phase is spelled out because this form has no tournament
+            // context: a quals card shown here is not in force during playoffs.
+            tooltip='Card this team carries for the rest of the phase it was issued in. Set automatically when a yellow is issued; clear it here if it was issued in error.'
+            extra={
+              team.cardPhase
+                ? `In force for ${team.cardPhase} matches only`
+                : undefined
+            }
+          >
+            <Select
+              value={team.cardStatus ?? CardStatus.NO_CARD}
+              onChange={handleCardStatusChange}
+              disabled={loading}
+              size='large'
+              options={[
+                { value: CardStatus.NO_CARD, label: 'None' },
+                { value: CardStatus.YELLOW_CARD, label: 'Yellow Card' }
+              ]}
+            />
+          </Form.Item>
+        </Col>
       </Row>
       <Row justify='space-between'>
         <Col>{returnTo && <ViewReturn title='Back' href={returnTo} />}</Col>

--- a/libs/models/src/base/CardStatus.ts
+++ b/libs/models/src/base/CardStatus.ts
@@ -1,0 +1,18 @@
+/**
+ * Card issued to a team, shared across seasons.
+ *
+ * The numeric values are load-bearing: they are stored directly in
+ * `match_participant.cardStatus` and `team.cardStatus`, and several seasons
+ * compare with `<=` to mean "no card or merely a yellow". Do not renumber.
+ *
+ * Each season module previously declared its own identical copy of this enum.
+ * They now re-export this one so that logic which is not season-specific —
+ * card carry-over, in particular — is not arbitrarily bound to whichever
+ * season's copy happened to be imported.
+ */
+export enum CardStatus {
+  WHITE_CARD = 3,
+  RED_CARD = 2,
+  YELLOW_CARD = 1,
+  NO_CARD = 0
+}

--- a/libs/models/src/base/Team.ts
+++ b/libs/models/src/base/Team.ts
@@ -12,8 +12,25 @@ export const teamZod = z.object({
   country: z.string(),
   countryCode: z.string().max(2),
   rookieYear: z.number(),
+  /**
+   * The card this team is *carrying* for the event, as a {@link CardStatus}.
+   *
+   * Distinct from `MatchParticipant.cardStatus`, which is the card issued in
+   * one specific match and clears at the next prestart. This one persists once
+   * a yellow is issued, and exists so the audience display can show that a team
+   * is carrying a card. It is advisory only: it never feeds scoring, rankings,
+   * or referee screens, and a second yellow does not escalate it to a red.
+   */
   cardStatus: z.number(),
-  hasCard: z.coerce.boolean()
+  /** Convenience mirror of `cardStatus !== CardStatus.NO_CARD`. Always written together with it. */
+  hasCard: z.coerce.boolean(),
+  /**
+   * Which {@link CardCarryPhase} the carried card belongs to, or `null` when
+   * there is no carried card. Cards do not cross the qualification/playoff
+   * boundary, so a card is only in force while this matches the phase of the
+   * tournament being played — `GET /match/all` blanks it otherwise.
+   */
+  cardPhase: z.string().nullable().optional()
 });
 
 export const defaultTeam: Team = {
@@ -56,7 +73,8 @@ export const TeamKeysLables: Record<TeamKey, string> = {
   teamNumber: 'Team Number',
   rookieYear: 'Rookie Year',
   cardStatus: 'Card Status',
-  hasCard: 'Has Card'
+  hasCard: 'Has Card',
+  cardPhase: 'Card Phase'
 };
 
 export type Team = z.infer<typeof teamZod>;

--- a/libs/models/src/base/Tournament.ts
+++ b/libs/models/src/base/Tournament.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { tournamentTypeZod } from './Schedule.js';
+import { UnreachableError } from '../types.js';
 
 export const tournamentZod = z.object({
   eventKey: z.string(),
@@ -53,6 +54,58 @@ export const isPlayoffsTournament = (tournament: Tournament): boolean => {
     tournament.tournamentType === 'Finals' ||
     tournament.tournamentType === 'Round Robin'
   );
+};
+
+/**
+ * The span a carried card is valid for. Cards do not follow a team across the
+ * boundary between these.
+ */
+export enum CardCarryPhase {
+  QUALIFICATION = 'qualification',
+  PLAYOFF = 'playoff'
+}
+
+/**
+ * Which phase a card issued in this tournament carries through, or `null` if it
+ * does not carry at all.
+ *
+ * Keyed on `tournamentType`, deliberately **not** on `tournamentLevel`. A
+ * numeric threshold cannot express this rule: ranking matches are qualification
+ * matches, but `RANKING_LEVEL` is 30 while `ROUND_ROBIN_LEVEL` — which is
+ * playoffs — is 20, so the levels are not ordered by phase and no cutoff
+ * separates them. Avoiding the level also avoids `getTournamentLevelFromType`
+ * mapping `'Eliminations'` to `PRACTICE_LEVEL` (see the TODO there), which any
+ * level-based check would have misread as "cards do not carry".
+ *
+ * The playoff arm lists exactly the types {@link isPlayoffsTournament} matches.
+ * They are spelled out rather than delegated to it because it returns a plain
+ * boolean, not a type guard, so calling it would leave the switch below
+ * non-exhaustive and silently defeat the compile-time check that matters here.
+ */
+export const getCardCarryPhase = (
+  tournament: Tournament
+): CardCarryPhase | null => {
+  switch (tournament.tournamentType) {
+    case 'Test':
+    case 'Practice':
+      // A card here is a per-match ruling and goes nowhere.
+      return null;
+    case 'Qualification':
+    case 'Ranking':
+      // Ranking rounds *are* qualification matches.
+      return CardCarryPhase.QUALIFICATION;
+    case 'Round Robin':
+    case 'Eliminations':
+    case 'Finals':
+      return CardCarryPhase.PLAYOFF;
+    default:
+      // Compile error if a TournamentType is added without deciding whether
+      // cards carry in it. Falls back to not carrying rather than throwing —
+      // this runs mid-event, and refusing to carry a card is the harmless way
+      // to be wrong.
+      new UnreachableError(tournament.tournamentType);
+      return null;
+  }
 };
 
 export type Tournament = z.infer<typeof tournamentZod>;

--- a/libs/models/src/base/index.ts
+++ b/libs/models/src/base/index.ts
@@ -3,6 +3,7 @@ export * from './Audience.js';
 export * from './User.js';
 export * from './Event.js';
 export * from './Team.js';
+export * from './CardStatus.js';
 export * from './ApiErrors.js';
 export * from './ApiStorage.js';
 export * from '../types.js';

--- a/libs/models/src/seasons/FGC25_EcoEquilibrium.ts
+++ b/libs/models/src/seasons/FGC25_EcoEquilibrium.ts
@@ -5,12 +5,9 @@ import { Ranking, rankingZod } from '../base/Ranking.js';
 import { isNonNullObject, isNumber } from '../types.js';
 import { Season, SeasonFunctions } from './index.js';
 
-export enum CardStatus {
-  WHITE_CARD = 3,
-  RED_CARD = 2,
-  YELLOW_CARD = 1,
-  NO_CARD = 0
-}
+// Re-exported from base so every season shares one definition; see CardStatus.ts.
+import { CardStatus } from '../base/CardStatus.js';
+export { CardStatus };
 
 // Protection Multiplier is sum of robot park states + 1
 const calcProtectionMultiplier = (

--- a/libs/models/src/seasons/FGC26_IgnitingInnovation.ts
+++ b/libs/models/src/seasons/FGC26_IgnitingInnovation.ts
@@ -5,12 +5,9 @@ import { Ranking, rankingZod } from '../base/Ranking.js';
 import { isNonNullObject, isNumber } from '../types.js';
 import { Season, SeasonFunctions } from './index.js';
 
-export enum CardStatus {
-  WHITE_CARD = 3,
-  RED_CARD = 2,
-  YELLOW_CARD = 1,
-  NO_CARD = 0
-}
+// Re-exported from base so every season shares one definition; see CardStatus.ts.
+import { CardStatus } from '../base/CardStatus.js';
+export { CardStatus };
 
 /**
  * BraceState

--- a/libs/models/src/seasons/FeedingTheFuture.ts
+++ b/libs/models/src/seasons/FeedingTheFuture.ts
@@ -4,12 +4,9 @@ import { Ranking } from '../base/Ranking.js';
 import { isNonNullObject, isNumber } from '../types.js';
 import { Season, SeasonFunctions } from './index.js';
 
-export enum CardStatus {
-  WHITE_CARD = 3,
-  RED_CARD = 2,
-  YELLOW_CARD = 1,
-  NO_CARD = 0
-}
+// Re-exported from base so every season shares one definition; see CardStatus.ts.
+import { CardStatus } from '../base/CardStatus.js';
+export { CardStatus };
 
 /**
  * Score Table


### PR DESCRIPTION
Closes audit findings **#4 and #5** of #236. Third of four stacked PRs — **based on #256**, review/merge after it.

## The finding

Card carry-over was never implemented. The referee `TeamSheet` writes a card to `match_participant`, and the next prestart zeroes it — so a yellow vanished the moment the following match was prestarted.

`Team.hasCard` and `Team.cardStatus` existed for exactly this and were never written by anything. They weren't dead columns; they were the schema for a missing feature.

## The rule implemented

A yellow issued in a match carries on the team — **but only through the phase it was issued in.**

- **Qualification and playoffs are separate.** A card does not follow a team out of quals into playoffs.
- **Ranking rounds count as qualification.** They are qualification matches.
- **Test and practice cards go nowhere.** They stay per-match.
- **A card survives within a phase**, so Quarterfinals → Semifinals → Finals keeps it.
- **Advisory and display-only.** Never touches scoring, rankings, or referee screens, and pre-selects nothing.
- **No escalation.** A second yellow does not become a red; the scorekeeper is prompted to **consult with HR**, because that call belongs to a human.

## Phase is keyed on `tournamentType`, not `tournamentLevel`

Worth pausing on, because the obvious implementation is wrong. A numeric threshold **cannot express this rule**: ranking matches are qualification matches, but `RANKING_LEVEL` is `30` while `ROUND_ROBIN_LEVEL` — which is playoffs — is `20`. The levels are not ordered by phase, so no `>` cutoff separates them.

`tournamentType` is a closed 7-value union that maps cleanly:

| `tournamentType` | phase |
|---|---|
| `Test`, `Practice` | none — no carry |
| `Qualification`, `Ranking` | qualification |
| `Round Robin`, `Eliminations`, `Finals` | playoff |

The switch is exhaustive, so adding an eighth `TournamentType` is a **compile error** until someone decides whether cards carry in it.

Keying on the type also sidesteps a live bug: `getTournamentLevelFromType` maps `'Eliminations'` to `PRACTICE_LEVEL` (an existing `TODO`), so an Eliminations tournament can carry a level claiming to be practice — which anything level-based would have read as "cards don't carry".

## Reset by scoping, not by wiping

Rather than detecting a phase transition and clearing rows, the phase is **stamped onto the card** and its validity scoped: `GET /match/all` blanks a carried card belonging to a different phase than the tournament being played.

That cannot be missed or double-fired if a prestart is skipped or two scorekeepers are connected, it behaves correctly if someone drops back to a qual match after playoffs have begun, and it keeps the record that a team was carded in quals. Prestarting the first match of a new phase "resets" the cards with **no reset step to run**.

Because that one route is the authoritative source of `participant.team` for both the audience display and the HR prompt, no display component needed changing.

## Promotion

`POST /teams/carry-cards/:eventKey/:tournamentKey` derives the phase server-side, so the rule is single-sourced rather than trusting a client.

- Never clears a card **for the current phase** — a later clean match, or a replay, must not drop one.
- Does clear cards left over from a **finished** phase.
- **Test and practice are a complete no-op** — promoting nothing *and* clearing nothing, so a practice tournament run between quals and playoffs can't wipe cards teams are legitimately carrying.

Clearing a card issued in error stays a manual act, via the **Carried Card** control in the team editor, which now names the phase a card applies to.

## Also

- `team.cardPhase` column, migrated onto existing databases through the `runMigrations()` seam added in #255 — its second use, and the reason it was built generic.
- Hoists `CardStatus`, declared identically in all four season modules, into `libs/models/src/base`.

## Verification

Full turbo build green. 21 assertions through the real Fastify routes against an isolated `APPDATA`:

**Predicate** — all seven `TournamentType` values, plus the two cases that break naive implementations: `Ranking` → qualification despite level 30, and `Eliminations` stuck at `PRACTICE_LEVEL` → still playoff.

**Write path** — quals yellow stamps qualification; practice promotes nothing *and* does not clear an existing quals card; ranking shares the qualification phase; playoff promotion clears the spent quals card and stamps playoff; finals shares the playoff phase.

**Read path** — the same carried card shows on quals and ranking matches, and is blanked on practice and playoff matches, without damaging the rest of the team record.

**Migration** — `cardPhase` added to a pre-existing `team` table, rows preserved, second open a clean no-op.

Plus the 7 original promote-only invariants, re-run against a qualification tournament.
