### PR TITLE
Fix broken API routes found during the #236 audit

### DIFF
--- a/apps/services/api/src/controllers/Alliance.ts
+++ b/apps/services/api/src/controllers/Alliance.ts
@@ -97,7 +97,7 @@ async function allianceController(fastify: FastifyInstance) {
           `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND allianceRank = ${rank}`
         );
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else {
           reply.send(data);
         }

--- a/apps/services/api/src/controllers/Event.ts
+++ b/apps/services/api/src/controllers/Event.ts
@@ -59,7 +59,7 @@ async function eventController(fastify: FastifyInstance) {
             `eventKey = "${eventKey}"`
           );
           if (data.length === 0) {
-            reply.send(DataNotFoundError);
+            reply.code(DataNotFoundError.code).send(DataNotFoundError);
           } else {
             reply.send(data[0]);
           }

--- a/apps/services/api/src/controllers/Match.ts
+++ b/apps/services/api/src/controllers/Match.ts
@@ -6,7 +6,11 @@ import {
   matchParticipantZod,
   reconcileMatchParticipants,
   getFunctionsBySeasonKey,
-  getCardCarryPhase
+  getCardCarryPhase,
+  RESULT_BLUE_WIN,
+  RESULT_GAME_SPECIFIC,
+  RESULT_RED_WIN,
+  RESULT_TIE
 } from '@toa-lib/models';
 import { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
@@ -39,6 +43,33 @@ import { computeCycleTime } from '../util/CycleTime.js';
 
 const MatchArraySchema = z.array(matchWithDetailsZod);
 const MatchParticipantArraySchema = z.array(matchParticipantZod);
+
+const MatchScoreSchema = z.object({
+  redScore: z.number(),
+  blueScore: z.number(),
+  result: z.number()
+});
+
+const MatchScoreChangeSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  previous: MatchScoreSchema,
+  current: MatchScoreSchema,
+  resultChanged: z.boolean()
+});
+
+const RecalculateSkipSchema = z.object({
+  id: z.number(),
+  reason: z.string()
+});
+
+/** What `/recalculate-scores` actually did, so the caller can see it. */
+const RecalculateSummarySchema = z.object({
+  matchesExamined: z.number(),
+  matchesChanged: z.number(),
+  changes: z.array(MatchScoreChangeSchema),
+  skipped: z.array(RecalculateSkipSchema)
+});
 
 async function matchController(fastify: FastifyInstance) {
   // SPECIAL ROUTES
@@ -266,7 +297,7 @@ async function matchController(fastify: FastifyInstance) {
           `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id = ${id}`
         );
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else {
           reply.send(data);
         }
@@ -379,7 +410,7 @@ async function matchController(fastify: FastifyInstance) {
       schema: {
         params: EventTournamentIdParams,
         body: z.any(),
-        response: errorableSchema(EmptySchema),
+        response: errorableSchema(EmptySchema, InvalidDataError),
         tags: ['Matches']
       }
     },
@@ -398,7 +429,7 @@ async function matchController(fastify: FastifyInstance) {
           body.tournamentKey !== tournamentKey ||
           String(body.id) !== id
         ) {
-          reply.send(InvalidDataError);
+          reply.code(InvalidDataError.code).send(InvalidDataError);
           return;
         }
         const data = funcs?.detailsToJson ? funcs.detailsToJson(body) : body;
@@ -484,12 +515,17 @@ async function matchController(fastify: FastifyInstance) {
   );
 
   // Recalculate Match Scores
+  //
+  // Re-derives every played match's details and scores from the stored match
+  // details, and writes the results back. Previously this only logged what it
+  // would have changed and never replied at all, so callers hung until they
+  // timed out and the recalculated scores were thrown away.
   fastify.withTypeProvider<ZodTypeProvider>().post(
     '/recalculate-scores/:eventKey/:tournamentKey',
     {
       schema: {
         params: EventTournamentKeyParams,
-        response: errorableSchema(EmptySchema),
+        response: errorableSchema(RecalculateSummarySchema),
         tags: ['Matches']
       }
     },
@@ -502,11 +538,11 @@ async function matchController(fastify: FastifyInstance) {
         const funcs = getFunctionsBySeasonKey(
           eventKey.split('-')[0].toLowerCase()
         );
-        console.log(
+        logger.info(
           `Recalculating scores for event ${eventKey} tournament ${tournamentKey}`
         );
 
-        const match = await db.selectAllWhere(
+        const matches = await db.selectAllWhere(
           'match',
           `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND result > -1`
         );
@@ -518,19 +554,24 @@ async function matchController(fastify: FastifyInstance) {
         for (const detail of matchDetails) {
           detailsMap.set(detail.id, detail);
         }
-        for (const m of match) {
-          const detail = detailsMap.get(m.id);
-          if (!detail) {
-            console.log(
-              `No details found for match id ${m.id}, skipping score recalculation.`
-            );
+
+        const changes: z.infer<typeof MatchScoreChangeSchema>[] = [];
+        const skipped: z.infer<typeof RecalculateSkipSchema>[] = [];
+
+        for (const m of matches) {
+          const stored = detailsMap.get(m.id);
+          if (!stored) {
+            skipped.push({ id: m.id, reason: 'no match details found' });
             continue;
           }
+          // Parse the row the same way GET /all does before handing it to
+          // season code — the raw row is not the season's detail shape.
+          const detail = funcs?.detailsFromJson
+            ? (funcs.detailsFromJson(stored) ?? stored)
+            : stored;
           const newDetails = funcs?.calculateRankingPoints?.(detail);
           if (!newDetails) {
-            console.log(
-              `No new details returned for match id ${m.id}, skipping score recalculation.`
-            );
+            skipped.push({ id: m.id, reason: 'season returned no details' });
             continue;
           }
           const [redScore, blueScore] = funcs?.calculateScore?.({
@@ -538,37 +579,59 @@ async function matchController(fastify: FastifyInstance) {
             details: newDetails
           }) ?? [-1, -1];
 
-          if (redScore !== m.redScore) {
-            console.log(
-              `SCORE UPDATED: Match ${m.id} red score changed from ${m.redScore} to ${redScore}`
+          // Keep `result` consistent with the scores we just wrote. Leaving a
+          // stale result next to a changed score is worse than not recalculating
+          // at all. Game-specific results are decided by something other than
+          // the score comparison, so those are left alone.
+          const result =
+            m.result === RESULT_GAME_SPECIFIC
+              ? m.result
+              : redScore > blueScore
+                ? RESULT_RED_WIN
+                : blueScore > redScore
+                  ? RESULT_BLUE_WIN
+                  : RESULT_TIE;
+
+          await db.updateWhere(
+            'match_detail',
+            funcs?.detailsToJson ? funcs.detailsToJson(newDetails) : newDetails,
+            `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id = ${m.id}`
+          );
+
+          const scoreChanged =
+            redScore !== m.redScore || blueScore !== m.blueScore;
+          const resultChanged = result !== m.result;
+          if (scoreChanged || resultChanged) {
+            await db.updateWhere(
+              'match',
+              { redScore, blueScore, result },
+              `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id = ${m.id}`
             );
-          }
-          if (blueScore !== m.blueScore) {
-            console.log(
-              `SCORE UPDATED: Match ${m.id} blue score changed from ${m.blueScore} to ${blueScore}`
-            );
-          }
-          const oldWinBlue = m.blueScore > m.redScore;
-          const newWinBlue = blueScore > redScore;
-
-          const oldWinTie = m.blueScore === m.redScore;
-          const newWinTie = blueScore === redScore;
-
-          const coOpChanged =
-            detail.coopertitionLevel !== (newDetails as any).coopertitionLevel;
-
-          if (coOpChanged) {
-            console.log(
-              `CO-OP LEVEL CHANGED: Match ${m.id} CO-OP level changed from ${detail.coopertitionLevel} to ${(newDetails as any).coopertitionLevel}`
-            );
-          }
-
-          if (oldWinBlue !== newWinBlue || oldWinTie !== newWinTie) {
-            console.log(
-              `MATCH RESULT CHANGED: Match ${m.id} OLD: Red ${m.redScore} - Blue ${m.blueScore} NEW: Red ${redScore} - Blue ${blueScore}`
+            const change = {
+              id: m.id,
+              name: m.name,
+              previous: {
+                redScore: m.redScore,
+                blueScore: m.blueScore,
+                result: m.result
+              },
+              current: { redScore, blueScore, result },
+              resultChanged
+            };
+            changes.push(change);
+            logger.info(
+              `Match ${m.id} recalculated: ${m.redScore}-${m.blueScore} -> ${redScore}-${blueScore}` +
+                (resultChanged ? ` (result ${m.result} -> ${result})` : '')
             );
           }
         }
+
+        reply.status(200).send({
+          matchesExamined: matches.length,
+          matchesChanged: changes.length,
+          changes,
+          skipped
+        });
       } catch (e) {
         reply.code(500).send(InternalServerError(e));
       }

--- a/apps/services/api/src/controllers/Ranking.ts
+++ b/apps/services/api/src/controllers/Ranking.ts
@@ -230,7 +230,7 @@ async function rankingController(fastify: FastifyInstance) {
         const seasonKey = getSeasonKeyFromEventKey(eventKey);
         const functions = getFunctionsBySeasonKey(seasonKey);
         if (!functions) {
-          reply.send(SeasonFunctionsMissing);
+          reply.code(SeasonFunctionsMissing.code).send(SeasonFunctionsMissing);
           return;
         }
         if (playoffs) {

--- a/apps/services/api/src/controllers/ScheduleItem.ts
+++ b/apps/services/api/src/controllers/ScheduleItem.ts
@@ -19,7 +19,7 @@ async function scheduleItemController(fastify: FastifyInstance) {
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere('schedule', `eventKey = '${eventKey}'`);
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else {
           reply.send(data);
         }
@@ -39,7 +39,7 @@ async function scheduleItemController(fastify: FastifyInstance) {
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere('schedule', `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}"`);
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else {
           reply.send(data);
         }

--- a/apps/services/api/src/controllers/ScheduleParams.ts
+++ b/apps/services/api/src/controllers/ScheduleParams.ts
@@ -19,7 +19,7 @@ async function scheduleParamsController(fastify: FastifyInstance) {
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere('schedule_params', `eventKey = '${eventKey}'`);
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else {
           reply.send(data);
         }
@@ -39,7 +39,7 @@ async function scheduleParamsController(fastify: FastifyInstance) {
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere('schedule_params', `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}"`);
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else if (data.length === 0) {
           reply.send({ ...defaultScheduleParams, eventKey, tournamentKey });
         } else {

--- a/apps/services/api/src/controllers/Team.ts
+++ b/apps/services/api/src/controllers/Team.ts
@@ -13,20 +13,10 @@ const carryCardsZod = z.array(
 );
 
 async function teamController(fastify: FastifyInstance) {
-  // Get all teams (global)
-  fastify.withTypeProvider<ZodTypeProvider>().get(
-    '/',
-    { schema: { response: errorableSchema<typeof teamsZod>(teamsZod), tags: ['Teams'] } },
-    async (request, reply) => {
-      try {
-        const db = await getDB('global');
-        const data = await db.selectAll('team');
-        reply.send(data);
-      } catch (e) {
-        reply.code(500).send(InternalServerError(e));
-      }
-    }
-  );
+  // NOTE: there is deliberately no `GET /` here. It used to select `team` from
+  // the *global* database, which has no such table (teams are per-event), so it
+  // returned a 500 on every call. It had no callers. Teams are only meaningful
+  // scoped to an event — use `GET /:eventKey`.
 
   // Get teams by eventKey
   fastify.withTypeProvider<ZodTypeProvider>().get(
@@ -38,7 +28,7 @@ async function teamController(fastify: FastifyInstance) {
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere('team', `eventKey = "${eventKey}"`);
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else {
           reply.send(data);
         }
@@ -176,7 +166,7 @@ async function teamController(fastify: FastifyInstance) {
           `eventKey = "${eventKey}" AND teamKey = ${teamKey}`
         );
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else {
           reply.send({});
         }

--- a/apps/services/api/src/controllers/Tournament.ts
+++ b/apps/services/api/src/controllers/Tournament.ts
@@ -24,7 +24,7 @@ async function tournamentController(fastify: FastifyInstance) {
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere('tournament', `eventKey = "${eventKey}"`);
         if (!data) {
-          reply.send(DataNotFoundError);
+          reply.code(DataNotFoundError.code).send(DataNotFoundError);
         } else {
           reply.send(data.map((t: any) => tournamentDatabaseZod.parse(t)));
         }

--- a/apps/web/src/api/use-team-data.ts
+++ b/apps/web/src/api/use-team-data.ts
@@ -37,8 +37,9 @@ export const postCarriedCards = async (
 ): Promise<void> =>
   apiFetcher(`teams/carry-cards/${eventKey}/${tournamentKey}`, 'POST', cards);
 
-export const useTeams = (): SWRResponse<Team[], ApiResponseError> =>
-  useSWR('teams', (url) => apiFetcher(url, 'GET'));
+// `useTeams` was removed alongside the `GET /teams` route it called: that route
+// queried a `team` table on the global database, which does not exist, so it
+// 500'd on every call. Teams are per-event — use `useTeamsForEvent`.
 
 export const useTeamsForEvent = (
   eventKey: string | null | undefined,


### PR DESCRIPTION
Closes audit findings **#11, #12, #13** of #236. Last of four stacked PRs — **based on #257**, review/merge after it.

These aren't field-accuracy issues, but they're in the same routes the audit walked, and all three are outright broken.

## `GET /teams` returned 500 on every call

It selected `team` from the **global** database, which has no such table — teams are per-event. It had no callers, so the route and its unused `useTeams()` client hook are removed rather than reimplemented. `GET /teams/:eventKey` is the meaningful form. A comment marks the absence so it isn't "helpfully" re-added.

## `POST /match/recalculate-scores` hung and discarded its work

It never called `reply`, so callers hung until they timed out. And it never persisted anything it computed — it only `console.log`'d what it *would* have changed.

It now writes back the recalculated details and scores, and returns a summary of exactly what moved (`matchesExamined`, `matchesChanged`, per-match `previous`/`current`, and `skipped` with reasons).

**It also recomputes `result`.** This goes slightly beyond "persist the scores", and deliberately: leaving a stale `result` beside a corrected score is a worse state than not recalculating at all, since the two then disagree about who won. `RESULT_GAME_SPECIFIC` is decided by something other than comparing scores, so those are left alone.

> Flagging as a judgement call — say the word if you'd rather it not touch `result`.

Details are now parsed through `detailsFromJson` before being handed to season code, matching what `GET /all` already does. The raw database row is not the season's detail shape, so season functions were previously being fed the wrong thing.

## Error responses had the wrong status code

Handlers sent an `ApiError` via `reply.send()` with no status, producing an **HTTP 200** whose body didn't match the declared 200 schema. Found **12 sites, not the 5** the audit first spotted — same bug throughout. All now reply with the error's own code, and the one route that can return `InvalidDataError` declares its 400.

## Verification

Full turbo build green. `recalculate-scores` exercised through the real route with a forced correction — seeded a match storing 50-0 / `RESULT_RED_WIN` against details that compute to 0-0:

- route replies (previously hung forever) ✓
- reply reports previous 50-0 → current 0-0, `resultChanged: true` ✓
- **corrected score persisted to the DB** ✓
- `result` persisted and consistent (RED_WIN → TIE) ✓
