### PR TITLE
Add updatedAtUtc to matches and ?since= to the match GETs

### DIFF
--- a/apps/services/api/sql/create_event.sql
+++ b/apps/services/api/sql/create_event.sql
@@ -117,6 +117,7 @@ CREATE TABLE IF NOT EXISTS "match" (
     "active" INT,
     "result" INT,
     "uploaded" INT,
+    "updatedAtUtc" VARCHAR(255),
     PRIMARY KEY (eventKey, tournamentKey, id),
     UNIQUE (eventKey, tournamentKey, id),
     FOREIGN KEY (tournamentKey) REFERENCES "tournament"(tournamentKey)

--- a/apps/services/api/src/controllers/Match.ts
+++ b/apps/services/api/src/controllers/Match.ts
@@ -40,6 +40,13 @@ import {
 import { matchWithDetailsZod } from '@toa-lib/models/base';
 import { platform } from 'os';
 import { computeCycleTime } from '../util/CycleTime.js';
+import {
+  nowUtc,
+  participantsSinceClause,
+  sinceClause,
+  SinceQuery,
+  touchMatch
+} from '../util/MatchTimestamps.js';
 
 const MatchArraySchema = z.array(matchWithDetailsZod);
 const MatchParticipantArraySchema = z.array(matchParticipantZod);
@@ -133,6 +140,7 @@ async function matchController(fastify: FastifyInstance) {
     {
       schema: {
         params: EventKeyParams,
+        querystring: SinceQuery,
         response: errorableSchema(z.union([z.any(), MatchArraySchema])),
         tags: ['Matches']
       }
@@ -140,10 +148,11 @@ async function matchController(fastify: FastifyInstance) {
     async (request, reply) => {
       try {
         const { eventKey } = request.params as z.infer<typeof EventKeyParams>;
+        const { since } = request.query as z.infer<typeof SinceQuery>;
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere(
           'match',
-          `eventKey = "${eventKey}"`
+          `eventKey = "${eventKey}"${sinceClause(since)}`
         );
         reply.send(data);
       } catch (e) {
@@ -158,6 +167,7 @@ async function matchController(fastify: FastifyInstance) {
     {
       schema: {
         params: EventKeyParams,
+        querystring: SinceQuery,
         response: errorableSchema(
           z.union([z.any(), MatchParticipantArraySchema])
         ),
@@ -167,10 +177,11 @@ async function matchController(fastify: FastifyInstance) {
     async (request, reply) => {
       try {
         const { eventKey } = request.params as z.infer<typeof EventKeyParams>;
+        const { since } = request.query as z.infer<typeof SinceQuery>;
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere(
           'match_participant',
-          `eventKey = "${eventKey}"`
+          `eventKey = "${eventKey}"${participantsSinceClause(since)}`
         );
         reply.send(data);
       } catch (e) {
@@ -185,6 +196,7 @@ async function matchController(fastify: FastifyInstance) {
     {
       schema: {
         params: EventTournamentKeyParams,
+        querystring: SinceQuery,
         response: errorableSchema(z.union([z.any(), MatchArraySchema])),
         tags: ['Matches']
       }
@@ -194,14 +206,27 @@ async function matchController(fastify: FastifyInstance) {
         const { eventKey, tournamentKey } = request.params as z.infer<
           typeof EventTournamentKeyParams
         >;
+        const { since } = request.query as z.infer<typeof SinceQuery>;
         const db = await getDB(eventKey);
         const data = await db.selectAllWhere(
           'match',
-          `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}"`
+          `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}"${sinceClause(
+            since
+          )}`
         );
+        // Nothing changed - skip the participants query rather than pulling the
+        // whole tournament's worth of rows to reconcile against an empty list.
+        if (data.length === 0) {
+          reply.send([]);
+          return;
+        }
+        // Fetch participants for the matches actually being returned. Ids come
+        // back from SQLite as numbers, but they are going into concatenated
+        // SQL, so coerce rather than trusting that.
+        const ids = data.map((match) => Number(match.id)).join(', ');
         const participants = await db.selectAllWhere(
           'match_participant',
-          `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}"`
+          `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id IN (${ids})`
         );
         reply.send(reconcileMatchParticipants(data, participants));
       } catch (e) {
@@ -322,8 +347,10 @@ async function matchController(fastify: FastifyInstance) {
       try {
         const { eventKey } = request.params as z.infer<typeof EventKeyParams>;
         const db = await getDB(eventKey);
+        const insertedAt = nowUtc();
         const pureMatches: Match<any>[] = request.body.map((m: Match<any>) => ({
-          ...m
+          ...m,
+          updatedAtUtc: insertedAt
         }));
         for (const match of pureMatches) delete match.participants;
         const participants = request.body
@@ -366,6 +393,9 @@ async function matchController(fastify: FastifyInstance) {
         const match = request.body as z.infer<typeof matchWithDetailsZod>;
         if (match.details) delete match.details;
         if (match.participants) delete match.participants;
+        // Server-owned, like cycleTime below: clients echo back whatever they
+        // were last handed, which would pin the timestamp to a stale value.
+        delete match.updatedAtUtc;
 
         // Cycle time is derived, never client-supplied, so that every client
         // agrees on it. Recomputed only on the patch that first records this
@@ -384,13 +414,15 @@ async function matchController(fastify: FastifyInstance) {
         }
 
         if (match.active === 1) {
+          // Those matches really did change, so they get a new timestamp too.
           await db.updateWhere(
             'match',
-            { active: 0 },
+            { active: 0, updatedAtUtc: nowUtc() },
             'active = 1 AND fieldNumber = ' + match.fieldNumber
           );
         }
 
+        match.updatedAtUtc = nowUtc();
         await db.updateWhere(
           'match',
           match,
@@ -438,6 +470,7 @@ async function matchController(fastify: FastifyInstance) {
           data,
           `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id = ${id}`
         );
+        await touchMatch(db, eventKey, tournamentKey, id);
         reply.status(200).send({});
       } catch (e) {
         reply.code(500).send(InternalServerError(e));
@@ -472,6 +505,7 @@ async function matchController(fastify: FastifyInstance) {
             `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id = ${id} AND station = ${station}`
           );
         }
+        await touchMatch(db, eventKey, tournamentKey, id);
         reply.status(200).send({});
       } catch (e) {
         reply.code(500).send(InternalServerError(e));
@@ -592,15 +626,30 @@ async function matchController(fastify: FastifyInstance) {
                   ? RESULT_BLUE_WIN
                   : RESULT_TIE;
 
+          const detailUpdate = funcs?.detailsToJson
+            ? funcs.detailsToJson(newDetails)
+            : newDetails;
           await db.updateWhere(
             'match_detail',
-            funcs?.detailsToJson ? funcs.detailsToJson(newDetails) : newDetails,
+            detailUpdate,
             `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id = ${m.id}`
           );
 
           const scoreChanged =
             redScore !== m.redScore || blueScore !== m.blueScore;
           const resultChanged = result !== m.result;
+          // Details are rewritten for every examined match, usually with values
+          // identical to what was already there. Compare the columns actually
+          // being written against the stored row so that a recalculation that
+          // changes nothing doesn't bump every match's `updatedAtUtc` and make
+          // every consumer re-fetch the whole tournament. Ranking points can
+          // move without the score moving, so this can't just key off the score.
+          const detailsChanged = Object.entries(
+            detailUpdate as Record<string, unknown>
+          ).some(([key, value]) => stored[key] !== value);
+          if (scoreChanged || resultChanged || detailsChanged) {
+            await touchMatch(db, eventKey, tournamentKey, m.id);
+          }
           if (scoreChanged || resultChanged) {
             await db.updateWhere(
               'match',

--- a/apps/services/api/src/controllers/Results.ts
+++ b/apps/services/api/src/controllers/Results.ts
@@ -15,6 +15,7 @@ import { getDB } from '../db/EventDatabase.js';
 import logger from '../util/Logger.js';
 import { z } from 'zod';
 import { errorableSchema } from '../util/Errors.js';
+import { nowUtc } from '../util/MatchTimestamps.js';
 import {
   EventKeyParams,
   EventTournamentKeyParams,
@@ -141,7 +142,7 @@ export const postMatchResults = async (
   if (res?.ok) {
     await db.updateWhere(
       'match',
-      { uploaded: 1 },
+      { uploaded: 1, updatedAtUtc: nowUtc() },
       `eventKey = "${info.eventKey}" AND tournamentKey = "${info.tournamentKey}" AND id = ${info.id}`
     );
   }

--- a/apps/services/api/src/db/EventDatabase.ts
+++ b/apps/services/api/src/db/EventDatabase.ts
@@ -78,6 +78,21 @@ export class EventDatabase {
     // Carried cards are scoped to a qualification/playoff phase rather than to
     // the whole event; this records which phase a team's card belongs to.
     await this.addColumnIfMissing('team', 'cardPhase', 'VARCHAR(15)');
+    // Lets consumers reconcile which matches changed since their last poll,
+    // and backs the `?since=` filter on the match routes; see issue #240.
+    await this.addColumnIfMissing('match', 'updatedAtUtc', 'VARCHAR(255)');
+    // Rows predating the column have no recorded write time. Stamp them now so
+    // that `?since=` has a total order to work with: a null would have to be
+    // either dropped from every filtered response (the consumer never learns
+    // the match exists) or included in all of them (the filter saves nothing).
+    // "as far as this server knows, last written at upgrade time" is the
+    // conservative answer - an older cursor still sees the row, a newer one
+    // correctly skips it.
+    await this.backfillNullColumn(
+      'match',
+      'updatedAtUtc',
+      new Date().toISOString()
+    );
   }
 
   /**
@@ -117,6 +132,34 @@ export class EventDatabase {
       if (await this.columnNames(table).then((n) => n.includes(column))) return;
       await this.db.exec(
         `ALTER TABLE "${table}" ADD COLUMN "${column}" ${type};`
+      );
+    } catch (e) {
+      throw new ApiDatabaseError(table, e);
+    }
+  }
+
+  /**
+   * Gives `column` a value on rows that don't have one yet.
+   *
+   * Idempotent by construction: it only touches nulls, so a second run matches
+   * nothing. No-ops on a database where `table` doesn't exist, and on a brand
+   * new one it matches zero rows because inserts populate the column already.
+   *
+   * Doubles as a safety net — if a write path is ever missed, those rows pick
+   * up a timestamp on the next restart instead of staying invisible to
+   * timestamp-filtered queries forever.
+   */
+  private async backfillNullColumn(
+    table: string,
+    column: string,
+    value: string
+  ): Promise<void> {
+    try {
+      if (!(await this.tableExists(table))) return;
+      if (!(await this.columnNames(table)).includes(column)) return;
+      await this.db.all(
+        `UPDATE "${table}" SET "${column}" = ? WHERE "${column}" IS NULL;`,
+        [value]
       );
     } catch (e) {
       throw new ApiDatabaseError(table, e);

--- a/apps/services/api/src/middleware/ErrorHandler.ts
+++ b/apps/services/api/src/middleware/ErrorHandler.ts
@@ -1,13 +1,21 @@
 import logger from '../util/Logger.js';
 import { ApiDatabaseError, ApiError, isApiError } from '@toa-lib/models';
 import { FastifyError, FastifyReply, FastifyRequest } from 'fastify';
+import { hasZodFastifySchemaValidationErrors } from 'fastify-type-provider-zod';
 
 const handleErrors = (
   error: unknown,
   req: FastifyRequest,
   reply: FastifyReply
 ) => {
-  if (error instanceof ApiDatabaseError) {
+  if (hasZodFastifySchemaValidationErrors(error)) {
+    // A schema violation is the caller's mistake, not ours. Without this branch
+    // it falls through to the catch-all below and every malformed request — a
+    // bad `?since=` cursor, a mistyped body — comes back as a 500, sending API
+    // consumers off hunting for a server-side bug that isn't there.
+    logger.warn(`[400] ${error.message} (${req.method} - ${req.originalUrl})`);
+    reply.status(400).send({ code: 400, message: error.message });
+  } else if (error instanceof ApiDatabaseError) {
     logger.error(`[500] ${error.message} (${req.method} - ${req.originalUrl})`);
     reply.status(500).send(toApiError(error));
   } else if (isApiError(error) && error.code <= 500) {

--- a/apps/services/api/src/util/MatchTimestamps.ts
+++ b/apps/services/api/src/util/MatchTimestamps.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import { EventDatabase } from '../db/EventDatabase.js';
+
+export const nowUtc = (): string => new Date().toISOString();
+
+/**
+ * Bumps a match's `updatedAtUtc`.
+ *
+ * Call this for participant and detail writes too — the timestamp covers the
+ * whole match aggregate, not just the `match` row, so that a consumer polling
+ * `?since=` gets the match back whichever part of it changed.
+ */
+export const touchMatch = async (
+  db: EventDatabase,
+  eventKey: string,
+  tournamentKey: string,
+  id: number | string
+): Promise<void> => {
+  await db.updateWhere(
+    'match',
+    { updatedAtUtc: nowUtc() },
+    `eventKey = "${eventKey}" AND tournamentKey = "${tournamentKey}" AND id = ${id}`
+  );
+};
+
+/**
+ * `?since=<iso8601>` reconciliation cursor.
+ *
+ * Declared here rather than in `@toa-lib/models` on purpose: `GlobalSchema`
+ * registers every zod schema exported from that package into the global
+ * registry, and @fastify/swagger crashes when a querystring schema gets $ref'd
+ * (see the `ParamsSchemaIds` note in `GlobalSchema.ts`).
+ */
+export const SinceQuery = z.object({
+  since: z.iso
+    // `offset: true` accepts `+00:00`-style zones alongside `Z`. Consumers echo
+    // back timestamps through their own date libraries, plenty of which
+    // serialize UTC as an explicit zero offset; rejecting those would be a
+    // gratuitous round-tripping failure. A zone of some kind is still required,
+    // since a bare local time doesn't name an instant.
+    .datetime({ offset: true })
+    .optional()
+    .describe(
+      'ISO-8601 UTC instant. Returns only records whose updatedAtUtc is strictly ' +
+        'after it. Advance the cursor using the largest updatedAtUtc in the ' +
+        'response, keeping your previous cursor when the response is empty.'
+    )
+});
+
+/**
+ * SQL fragment restricting rows to those updated strictly after `since`, or an
+ * empty string when no cursor was supplied. Intended to be appended to an
+ * existing `WHERE` clause.
+ *
+ * `since` is re-serialized rather than interpolated as given, which matters
+ * twice over:
+ *
+ *  - **Safety.** `selectAllWhere` builds SQL by string concatenation, and
+ *    canonical `toISOString()` output cannot carry a quote or a SQL fragment.
+ *    The zod schema rejects malformed input before we get here, so this is
+ *    belt-and-braces — but the belt is what keeps a future schema change from
+ *    turning into an injection.
+ *  - **Correctness.** This is a string comparison in SQLite, which is only
+ *    meaningful when both sides are canonical fixed-width UTC (`Z`, 3-digit
+ *    milliseconds). A consumer echoing back `2026-08-09T14:22:31+00:00`, or
+ *    dropping the milliseconds, would otherwise silently skip or re-fetch rows.
+ */
+export const sinceClause = (since?: string): string => {
+  if (!since) return '';
+  return ` AND "updatedAtUtc" > "${canonical(since)}"`;
+};
+
+/**
+ * `sinceClause` for `match_participant`, which has no timestamp of its own and
+ * is filtered by its parent match instead.
+ *
+ * Correlating on `tournamentKey` as well as `id` is not optional:
+ * `match_participant`'s primary key is `(eventKey, tournamentKey, id, station)`,
+ * so match ids repeat across tournaments within an event, and an id-only
+ * subquery would hand back participants from the wrong tournament.
+ */
+export const participantsSinceClause = (since?: string): string => {
+  if (!since) return '';
+  return (
+    ` AND EXISTS (SELECT 1 FROM "match" WHERE` +
+    ` "match"."eventKey" = "match_participant"."eventKey"` +
+    ` AND "match"."tournamentKey" = "match_participant"."tournamentKey"` +
+    ` AND "match"."id" = "match_participant"."id"` +
+    ` AND "match"."updatedAtUtc" > "${canonical(since)}")`
+  );
+};
+
+const canonical = (since: string): string => new Date(since).toISOString();

--- a/apps/services/api/src/util/Webhooks.ts
+++ b/apps/services/api/src/util/Webhooks.ts
@@ -17,7 +17,8 @@ const PERSISTED_FIELDS = [
   'cycleTime',
   'fieldNumber',
   'active',
-  'uploaded'
+  'uploaded',
+  'updatedAtUtc'
 ] as const;
 
 /**

--- a/libs/models/src/base/Match.ts
+++ b/libs/models/src/base/Match.ts
@@ -122,6 +122,14 @@ export type Match<T extends MatchDetailBase> = {
   active: number;
   result: number;
   uploaded: number;
+  /**
+   * When this match was last written, as an ISO-8601 UTC string. Covers the
+   * whole match — a change to its participants or details bumps it too, so a
+   * consumer can reconcile on this one value. Server-owned: any value sent by a
+   * client is discarded. Optional only so that code constructing a new match
+   * doesn't have to invent one; the API always populates it.
+   */
+  updatedAtUtc?: string;
   participants?: MatchParticipant[];
   details?: T;
 };
@@ -145,6 +153,7 @@ export const matchZod: z.ZodSchema<Match<MatchDetailBase>> = z.object({
   active: z.number(),
   result: z.number(),
   uploaded: z.number(),
+  updatedAtUtc: z.string().optional(),
   participants: z.array(matchParticipantZod).optional(),
   details: matchKeyZod.optional()
 });


### PR DESCRIPTION
Closes #240. Fifth in the stacked chain — **base is `fix/236-api-bugs` (#258)**; review/merge #255 → #256 → #257 → #258 → this.

Consumers had no way to tell which matches changed since their last poll, so reconciling meant re-fetching every match in a tournament and diffing locally. Raised in Discord by alliancecaptain.

## Matches carry a server-owned `updatedAtUtc`

Bumped on every write to the match aggregate — the row itself, its participants, and its details, plus `/recalculate-scores` and the `uploaded: 1` write in `postMatchResults`. **One timestamp per match rather than per table**, because `GET /match/all/...` hands back all three joined together and a consumer wants a single value to compare. Details and participant writes bump their parent through a shared `touchMatch`.

Client-supplied values are discarded — the same rule #255 already applies to `cycleTime`, and for the same reason: clients PATCH back whatever object they were last handed, which would pin the timestamp to a stale value.

Added to `matchZod`, not just the table. The web client parses responses through `matchZod.array().parse` and zod strips unknown keys, so without that the field silently vanishes for every consumer.

## `?since=<iso8601>` on the three match GETs

Returns only records updated strictly after the cursor, **as a bare array** so no existing response changes shape. Advance the cursor with `max(updatedAtUtc)` from the response, keeping your previous cursor when the response is empty — that is race-free where a server clock is not, since a write landing mid-request gets picked up on the next poll instead of skipped.

The cursor is re-serialized through `toISOString()` rather than interpolated as given. Twice-motivated: `selectAllWhere` builds SQL by concatenation, and these are *string* comparisons in SQLite, only meaningful when both sides are canonical fixed-width UTC. A consumer echoing back `+00:00` or dropping milliseconds would otherwise silently skip rows.

`match_participant` has no timestamp of its own and is filtered through its parent match. **The subquery correlates on `tournamentKey` as well as `id`** — the primary key is `(eventKey, tournamentKey, id, station)`, so match ids repeat across tournaments and an id-only lookup returns the wrong tournament's participants.

`GET /match/all/:e/:t/:id` deliberately has no `since`: it fetches one known record, and a consumer holding the key can compare the field itself.

## Existing databases get the column and a backfill

Through #255's `runMigrations` seam and #257's `addColumnIfMissing`, plus a new `backfillNullColumn` sibling.

**The backfill is what makes `?since=` total.** A null would have to be either dropped from every filtered response — so the consumer never learns that match exists — or included in all of them, so the filter saves nothing. Stamping existing rows at upgrade time is the conservative reading: "as far as this server knows, last written at upgrade", so an older cursor still sees the row and a newer one correctly skips it. It only touches nulls, so it is idempotent, and it doubles as a safety net if a write path is ever missed.

## `/recalculate-scores` bumps only what actually changed

That route rewrites `match_detail` for every examined match whether or not anything changed, so the bump compares the columns being written against the stored row rather than keying off the score alone — ranking points can move without the score moving. A no-op recalculation must not make every consumer re-download the tournament.

## Validation errors were coming back as 500s

`handleErrors` did not recognise fastify's validation errors, so a malformed `?since=` cursor — or any bad body or params, **on any route** — fell through to the catch-all and reported a server fault for what is the caller's mistake. For a feature whose audience is third-party integrators, that is the difference between usable and not, so it is fixed here rather than deferred.

Blast radius checked: only `PATCH /match/details/...` declares a literal-message 400, and its body schema is `z.any()`, so it cannot produce a validation error whose body would fail that serializer. Existing 500s and 404s are unchanged.

> `z.iso.datetime()` also needed `{ offset: true }` — it rejects `+00:00` by default, and plenty of date libraries serialize UTC as an explicit zero offset. A zone is still required; a bare local time doesn't name an instant.

## Verification

Full turbo build green. Beyond typechecking, exercised against real SQLite and a live server bound to an isolated `APPDATA` (no real event database was opened):

- **Migration**, 11 checks — seeded a pre-#240 database: column added, every row backfilled with a canonical instant, other values intact, second open a clean no-op with **no re-stamping**, a manually nulled row repaired on next open without disturbing its neighbours, table-less database unaffected.
- **Routes**, 26 checks — stamping on insert and all three PATCH paths; old cursor returns exactly the unfiltered response; future cursor returns `[]`; a single edit returns only that match; polling again with `max(updatedAtUtc)` returns `[]`; a client-sent `1999-…` timestamp is discarded; details-only and participants-only writes each bump their parent; offset-form cursor matches the canonical form; `?since=yesterday` and an injection probe both 400; participants correlate on `tournamentKey` (same match id in a second tournament is not dragged in); `since` documented at `/docs`.
- **Recalculate/webhooks**, 9 checks — a no-op recalculation bumps nothing, a real score change bumps exactly one match, and a webhook sent with a deliberately stale `updatedAtUtc` is delivered carrying the database value.
- Confirmed the field survives the web client's `matchZod.array().parse`.

## Not in scope

Deletions still can't be detected by polling — that needs tombstones. `ranking`/`team`/`alliance` don't have the column yet; each is now an `addColumnIfMissing` line, a backfill line, and stamping per write path.
